### PR TITLE
fix: address Zenith audit issues

### DIFF
--- a/agent/INVARIANTS.md
+++ b/agent/INVARIANTS.md
@@ -37,8 +37,9 @@ skip-proof feature containment (`pnpm check:invariants`, baselines in
 - A bond-owner transfer must preserve the previous owner's locked-FOLD coverage. The wallet balance
   plus remaining bonds must equal or exceed `lockedBalanceOf(previousOwner)`. —
   `BondingRegistry.acceptBondOwner`; `flow-trace/01`, `02`
-- Bonding-asset rotation only after old-asset balances fully drain; replacement assets must be
-  deployed contracts. — `flow-trace/02`; INDEX concern #23
+- Bonding-asset rotation only after old-asset balances fully drain. Replacement assets must be
+  deployed contracts, and a replacement license token must return a valid value from
+  `lockedBalanceOf`. — `flow-trace/02`; INDEX concern #23
 
 ### Activation (auto-evaluated in `_updateOperatorStatus`, never a standalone call)
 

--- a/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
+++ b/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
@@ -494,6 +494,9 @@ enforcement based on immutable policy curves. Key changes:
 - **Immutable constructor parameters.** `CCA_START`, `CCA_END`, `CLAIM_SOURCE`, and
   `BONDING_REGISTRY` are set at construction and cannot change. The BondingRegistry must be deployed
   first (or a placeholder used and fixed via `setLicenseToken`).
+- **License-token compatibility.** Each nonzero token passed to `setLicenseToken` must return one
+  ABI-encoded `uint256` from `lockedBalanceOf(address)`. This keeps funded bond-owner transfers
+  available after a token rotation.
 - **Lock policy system.** `createLockPolicy(id, LockPolicy)` creates write-once policies with
   `Curve { anchor (Absolute|Tge), start, cliffDuration, vestDuration }` and optional `holdUntil`.
   `linkClaim(account, amount, policyId)` classifies pending claim-source tokens under a real policy.

--- a/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
+++ b/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
@@ -226,16 +226,17 @@ CiphernodeRegistrySolWriter receives TicketGenerated event
     │  │    3. require(block.timestamp <= committeeDeadline)     │
     │  │    4. require(!submitted[msg.sender])                   │
     │  │       → Each node submits only once                     │
-    │  │    5. require(isCiphernodeEligible(msg.sender))         │
-    │  │       → Must be enabled AND bondingRegistry.isActive()  │
+    │  │    5. require(isEnabled(msg.sender) AND                 │
+    │  │               _bondingFor(e3Id).isActive(msg.sender))   │
+    │  │       → Uses the request-time bonding registry          │
     │  │       → Active status fails closed for a retained ban   │
     │  │                                                         │
     │  │    6. _validateNodeEligibility(e3Id, msg.sender,        │
     │  │                                ticketNumber):           │
     │  │       availableTickets =                                │
-    │  │         bondingRegistry.getTicketBalanceAtBlock(         │
+    │  │         _bondingFor(e3Id).getTicketBalanceAtBlock(      │
     │  │           msg.sender, requestBlock - 1                  │
-    │  │         ) / bondingRegistry.ticketPrice()               │
+    │  │         ) / _bondingFor(e3Id).ticketPrice()             │
     │  │       → Calls ticketToken.getPastVotes() internally     │
     │  │       → Uses SNAPSHOT from block before request         │
     │  │       → Prevents same-block manipulation                │
@@ -444,10 +445,10 @@ The registry must finalize a ready committee.
 ### H-04 — snapshot-based eligibility
 
 `CiphernodeRegistryOwnable._validateNodeEligibility` derives the per-node ticket weight from
-`bondingRegistry.getTicketBalanceAtBlock(node, committee.requestBlock - 1)`, which reads the
+`_bondingFor(e3Id).getTicketBalanceAtBlock(node, committee.requestBlock - 1)`, which reads the
 `InterfoldTicketToken` ERC20Votes checkpoint history (EIP-6372 timestamp clock). Same-block or
-post-request rebalancing therefore cannot inflate a node's selection weight; the outer
-`isCiphernodeEligible(msg.sender)` still gates on the current `isActive` flag for liveness.
+post-request rebalancing therefore cannot inflate a node's selection weight. `submitTicket` also
+checks the current `isActive` flag in the request-time bonding registry.
 
 ### M-33 — `markE3Failed` grace period
 

--- a/crates/dashboard/src/projection.rs
+++ b/crates/dashboard/src/projection.rs
@@ -6,6 +6,7 @@
 
 //! Pure EventStore-to-dashboard projection.
 
+use alloy::primitives::U256;
 use e3_events::{
     hlc::HlcTimestamp, E3Stage, Event, EventContextAccessors, EventContextSeq, EventSource,
     InterfoldEvent, InterfoldEventData,
@@ -132,6 +133,12 @@ pub struct RewardView {
 }
 
 #[derive(Clone, Debug, Serialize)]
+pub struct RewardAllocationView {
+    pub operator: String,
+    pub amount: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct E3Summary {
     pub e3_id: String,
     pub chain_id: u64,
@@ -153,6 +160,7 @@ pub struct E3Trace {
     pub committee: Vec<CommitteeMemberView>,
     pub tickets: Vec<TicketView>,
     pub rewards: Vec<RewardView>,
+    pub reward_allocations: Vec<RewardAllocationView>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<Value>,
     pub events: Vec<EventView>,
@@ -194,7 +202,12 @@ struct ChainState {
     license_bond: Option<String>,
     bond_owner: Option<String>,
     exit_unlock_at: Option<u64>,
-    rewards: Vec<RewardView>,
+    rewards: Vec<ChainReward>,
+}
+
+struct ChainReward {
+    e3_id: String,
+    view: RewardView,
 }
 
 #[derive(Default)]
@@ -209,6 +222,7 @@ struct E3State {
     tickets: Vec<TicketView>,
     expelled: BTreeSet<String>,
     rewards: Vec<RewardView>,
+    reward_allocations: Vec<RewardAllocationView>,
     failure: Option<Value>,
     failed_phase: Option<E3Phase>,
     first_seen_us: u64,
@@ -270,7 +284,11 @@ impl TelemetryProjection {
                     license_bond: state.license_bond.clone(),
                     bond_owner: state.bond_owner.clone(),
                     exit_unlock_at: state.exit_unlock_at,
-                    rewards_credited: state.rewards.clone(),
+                    rewards_credited: state
+                        .rewards
+                        .iter()
+                        .map(|reward| reward.view.clone())
+                        .collect(),
                 })
                 .collect(),
             e3_total: summaries.len(),
@@ -349,24 +367,31 @@ impl TelemetryProjection {
                     .entry(event.e3_id.chain_id())
                     .or_default()
                     .rewards
-                    .push(RewardView {
-                        account: event.account.clone(),
-                        token: Some(event.token.clone()),
-                        amount: event.amount.clone(),
-                        claimed: false,
+                    .push(ChainReward {
+                        e3_id: event.e3_id.to_string(),
+                        view: RewardView {
+                            account: event.account.clone(),
+                            token: Some(event.token.clone()),
+                            amount: event.amount.clone(),
+                            claimed: false,
+                        },
                     });
             }
             InterfoldEventData::RewardClaimed(event)
                 if normalize_address(&event.account) == self.local_address =>
             {
                 let state = self.chains.entry(event.e3_id.chain_id()).or_default();
-                if let Some(reward) = state.rewards.iter_mut().rev().find(|reward| {
-                    normalize_address(&reward.account) == self.local_address
-                        && reward.token.as_deref() == Some(event.token.as_str())
-                        && reward.amount == event.amount
-                }) {
-                    reward.claimed = true;
-                }
+                let e3_id = event.e3_id.to_string();
+                mark_claimed_rewards(
+                    state
+                        .rewards
+                        .iter_mut()
+                        .filter(|reward| reward.e3_id == e3_id)
+                        .map(|reward| &mut reward.view),
+                    &event.account,
+                    &event.token,
+                    &event.amount,
+                );
             }
             _ => {}
         }
@@ -446,15 +471,13 @@ impl TelemetryProjection {
                 _ => {}
             },
             InterfoldEventData::RewardsDistributed(event) => {
-                state.rewards = event
+                state.reward_allocations = event
                     .nodes
                     .iter()
                     .zip(&event.amounts)
-                    .map(|(account, amount)| RewardView {
-                        account: account.clone(),
-                        token: None,
+                    .map(|(operator, amount)| RewardAllocationView {
+                        operator: operator.clone(),
                         amount: amount.clone(),
-                        claimed: false,
                     })
                     .collect();
             }
@@ -467,13 +490,12 @@ impl TelemetryProjection {
                 });
             }
             InterfoldEventData::RewardClaimed(event) => {
-                if let Some(reward) = state.rewards.iter_mut().rev().find(|reward| {
-                    normalize_address(&reward.account) == normalize_address(&event.account)
-                        && reward.token.as_deref() == Some(event.token.as_str())
-                        && reward.amount == event.amount
-                }) {
-                    reward.claimed = true;
-                }
+                mark_claimed_rewards(
+                    state.rewards.iter_mut(),
+                    &event.account,
+                    &event.token,
+                    &event.amount,
+                );
             }
             _ => {}
         }
@@ -802,6 +824,7 @@ fn trace(state: &E3State) -> E3Trace {
             .collect(),
         tickets: state.tickets.clone(),
         rewards: state.rewards.clone(),
+        reward_allocations: state.reward_allocations.clone(),
         failure: state.failure.clone(),
         events: state.events.clone(),
     }
@@ -809,6 +832,49 @@ fn trace(state: &E3State) -> E3Trace {
 
 fn normalize_address(value: &str) -> String {
     value.to_ascii_lowercase()
+}
+
+fn mark_claimed_rewards<'a>(
+    rewards: impl IntoIterator<Item = &'a mut RewardView>,
+    account: &str,
+    token: &str,
+    claimed_amount: &str,
+) {
+    let Ok(claimed_amount) = claimed_amount.parse::<U256>() else {
+        return;
+    };
+    let account = normalize_address(account);
+    let token = normalize_address(token);
+    let mut matching = Vec::new();
+    let mut credited_amount = U256::ZERO;
+
+    for reward in rewards {
+        let matches = !reward.claimed
+            && normalize_address(&reward.account) == account
+            && reward
+                .token
+                .as_deref()
+                .is_some_and(|value| normalize_address(value) == token);
+        if !matches {
+            continue;
+        }
+
+        let Ok(amount) = reward.amount.parse::<U256>() else {
+            return;
+        };
+        let Some(next_credited_amount) = credited_amount.checked_add(amount) else {
+            return;
+        };
+        credited_amount = next_credited_amount;
+        matching.push(reward);
+    }
+
+    if credited_amount != claimed_amount {
+        return;
+    }
+    for reward in matching {
+        reward.claimed = true;
+    }
 }
 
 #[cfg(test)]
@@ -855,12 +921,15 @@ mod tests {
         let e3_id = e3_events::E3id::new("9", 31337);
         let account = "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65";
         let token = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512";
+        let operator_one = "0x1111111111111111111111111111111111111111";
+        let operator_two = "0x2222222222222222222222222222222222222222";
         let events = vec![
             replay_event(
-                RewardsDistributed {
+                RewardCredited {
                     e3_id: e3_id.clone(),
-                    nodes: vec![account.into()],
-                    amounts: vec!["42".into()],
+                    account: account.into(),
+                    token: token.into(),
+                    amount: "20".into(),
                 }
                 .into(),
                 1,
@@ -871,11 +940,21 @@ mod tests {
                     e3_id: e3_id.clone(),
                     account: account.into(),
                     token: token.into(),
-                    amount: "42".into(),
+                    amount: "22".into(),
                 }
                 .into(),
                 2,
                 20,
+            ),
+            replay_event(
+                RewardsDistributed {
+                    e3_id: e3_id.clone(),
+                    nodes: vec![operator_one.into(), operator_two.into()],
+                    amounts: vec!["20".into(), "22".into()],
+                }
+                .into(),
+                3,
+                30,
             ),
             replay_event(
                 RewardClaimed {
@@ -885,8 +964,8 @@ mod tests {
                     amount: "42".into(),
                 }
                 .into(),
-                3,
-                30,
+                4,
+                40,
             ),
         ];
 
@@ -911,6 +990,104 @@ mod tests {
             serde_json::to_value(live.trace("31337:9")).unwrap(),
             serde_json::to_value(rebuilt.trace("31337:9")).unwrap()
         );
+
+        let trace = live.trace("31337:9").unwrap();
+        assert_eq!(trace.rewards.len(), 2);
+        assert!(trace.rewards.iter().all(|reward| reward.claimed));
+        assert!(trace
+            .rewards
+            .iter()
+            .all(|reward| reward.account == account && reward.token.as_deref() == Some(token)));
+        assert_eq!(trace.reward_allocations.len(), 2);
+        assert_eq!(trace.reward_allocations[0].operator, operator_one);
+        assert_eq!(trace.reward_allocations[1].operator, operator_two);
+
+        let overview = live.overview();
+        let chain = overview
+            .chains
+            .iter()
+            .find(|chain| chain.chain_id == 31337)
+            .unwrap();
+        assert_eq!(chain.rewards_credited.len(), 2);
+        assert!(chain.rewards_credited.iter().all(|reward| reward.claimed));
+    }
+
+    #[test]
+    fn chain_reward_claims_are_scoped_to_one_e3() {
+        let claimed_e3 = e3_events::E3id::new("9", 31337);
+        let pending_e3 = e3_events::E3id::new("10", 31337);
+        let account = "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65";
+        let token = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512";
+        let events = [
+            RewardCredited {
+                e3_id: claimed_e3.clone(),
+                account: account.into(),
+                token: token.into(),
+                amount: "20".into(),
+            }
+            .into(),
+            RewardCredited {
+                e3_id: pending_e3,
+                account: account.into(),
+                token: token.into(),
+                amount: "22".into(),
+            }
+            .into(),
+            RewardClaimed {
+                e3_id: claimed_e3,
+                account: account.into(),
+                token: token.into(),
+                amount: "20".into(),
+            }
+            .into(),
+        ];
+
+        let mut projection = TelemetryProjection::new(account);
+        for (index, event) in events.into_iter().enumerate() {
+            projection.apply(replay_event(event, index as u64 + 1, index as u128 + 1));
+        }
+
+        let overview = projection.overview();
+        let rewards = &overview.chains[0].rewards_credited;
+        assert_eq!(rewards.len(), 2);
+        assert!(
+            rewards
+                .iter()
+                .find(|reward| reward.amount == "20")
+                .unwrap()
+                .claimed
+        );
+        assert!(
+            !rewards
+                .iter()
+                .find(|reward| reward.amount == "22")
+                .unwrap()
+                .claimed
+        );
+    }
+
+    #[test]
+    fn reward_claim_matching_rejects_aggregate_overflow() {
+        let account = "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65";
+        let token = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512";
+        let mut rewards = vec![
+            RewardView {
+                account: account.into(),
+                token: Some(token.into()),
+                amount: U256::MAX.to_string(),
+                claimed: false,
+            },
+            RewardView {
+                account: account.into(),
+                token: Some(token.into()),
+                amount: "2".into(),
+                claimed: false,
+            },
+        ];
+
+        mark_claimed_rewards(rewards.iter_mut(), account, token, "1");
+
+        assert!(rewards.iter().all(|reward| !reward.claimed));
     }
 
     fn replay_event(data: InterfoldEventData, seq: u64, timestamp: u128) -> InterfoldEvent {

--- a/crates/evm/src/interfold/events.rs
+++ b/crates/evm/src/interfold/events.rs
@@ -403,6 +403,13 @@ pub(crate) fn extractor(
         Some(&IInterfold::RewardsDistributed::SIGNATURE_HASH) => {
             let mut event = IInterfold::RewardsDistributed::decode_log_data(data)
                 .context("failed to decode RewardsDistributed after its topic matched")?;
+            if event.nodes.len() != event.amounts.len() {
+                anyhow::bail!(
+                    "RewardsDistributed array lengths differ: nodes={}, amounts={}",
+                    event.nodes.len(),
+                    event.amounts.len()
+                );
+            }
             event.e3Id = indexed_u256(topics, 1, "RewardsDistributed")?;
             Ok(Some(RewardsDistributedWithChainId(event, chain_id).into()))
         }
@@ -531,6 +538,22 @@ mod tests {
             }
             other => panic!("expected RewardCredited, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_extractor_rejects_mismatched_reward_arrays() {
+        let event = IInterfold::RewardsDistributed {
+            e3Id: U256::from(8),
+            nodes: vec![Address::repeat_byte(0x11), Address::repeat_byte(0x22)],
+            amounts: vec![U256::from(500)],
+        };
+        let log = event.encode_log_data();
+
+        let error = extractor(&log, log.topics(), 10).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("RewardsDistributed array lengths differ"));
     }
 
     #[test]

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/IBondingRegistry.sol/IBondingRegistry.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/IBondingRegistry.sol/IBondingRegistry.json
@@ -77,6 +77,17 @@
       "type": "error"
     },
     {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "IncompatibleLicenseToken",
+      "type": "error"
+    },
+    {
       "inputs": [],
       "name": "InsufficientBalance",
       "type": "error"
@@ -1560,5 +1571,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/IBondingRegistry.sol",
-  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
+  "buildInfoId": "solc-0_8_28-6fdcd65dfc524a2da4784f321f87605f7995a92a"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/IBondingRegistry.sol/IBondingRegistry.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/IBondingRegistry.sol/IBondingRegistry.json
@@ -1560,5 +1560,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/IBondingRegistry.sol",
-  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
+  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/IBondingRegistry.sol/IBondingRegistry.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/IBondingRegistry.sol/IBondingRegistry.json
@@ -1560,5 +1560,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/IBondingRegistry.sol",
-  "buildInfoId": "solc-0_8_28-333bedd9b9edefb785c3ddd79bdef9ffb671c898"
+  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/ICiphernodeRegistry.sol/ICiphernodeRegistry.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/ICiphernodeRegistry.sol/ICiphernodeRegistry.json
@@ -200,11 +200,6 @@
     },
     {
       "inputs": [],
-      "name": "OnlyBondingRegistry",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "OnlyInterfold",
       "type": "error"
     },
@@ -1408,5 +1403,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/ICiphernodeRegistry.sol",
-  "buildInfoId": "solc-0_8_28-333bedd9b9edefb785c3ddd79bdef9ffb671c898"
+  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/ICiphernodeRegistry.sol/ICiphernodeRegistry.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/ICiphernodeRegistry.sol/ICiphernodeRegistry.json
@@ -1403,5 +1403,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/ICiphernodeRegistry.sol",
-  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
+  "buildInfoId": "solc-0_8_28-6fdcd65dfc524a2da4784f321f87605f7995a92a"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/ICiphernodeRegistry.sol/ICiphernodeRegistry.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/ICiphernodeRegistry.sol/ICiphernodeRegistry.json
@@ -1078,7 +1078,7 @@
           "type": "bool"
         }
       ],
-      "stateMutability": "nonpayable",
+      "stateMutability": "view",
       "type": "function"
     },
     {
@@ -1403,5 +1403,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/ICiphernodeRegistry.sol",
-  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
+  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/IInterfold.sol/IInterfold.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/IInterfold.sol/IInterfold.json
@@ -2445,5 +2445,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/IInterfold.sol",
-  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
+  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/IInterfold.sol/IInterfold.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/IInterfold.sol/IInterfold.json
@@ -2445,5 +2445,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/IInterfold.sol",
-  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
+  "buildInfoId": "solc-0_8_28-6fdcd65dfc524a2da4784f321f87605f7995a92a"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/IInterfold.sol/IInterfold.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/IInterfold.sol/IInterfold.json
@@ -2445,5 +2445,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/IInterfold.sol",
-  "buildInfoId": "solc-0_8_28-333bedd9b9edefb785c3ddd79bdef9ffb671c898"
+  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/ISlashingManager.sol/ISlashingManager.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/ISlashingManager.sol/ISlashingManager.json
@@ -1432,5 +1432,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/ISlashingManager.sol",
-  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
+  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/ISlashingManager.sol/ISlashingManager.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/ISlashingManager.sol/ISlashingManager.json
@@ -1432,5 +1432,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/ISlashingManager.sol",
-  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
+  "buildInfoId": "solc-0_8_28-6fdcd65dfc524a2da4784f321f87605f7995a92a"
 }

--- a/packages/interfold-contracts/artifacts/contracts/interfaces/ISlashingManager.sol/ISlashingManager.json
+++ b/packages/interfold-contracts/artifacts/contracts/interfaces/ISlashingManager.sol/ISlashingManager.json
@@ -1432,5 +1432,5 @@
   "deployedLinkReferences": {},
   "immutableReferences": {},
   "inputSourceName": "project/contracts/interfaces/ISlashingManager.sol",
-  "buildInfoId": "solc-0_8_28-333bedd9b9edefb785c3ddd79bdef9ffb671c898"
+  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
 }

--- a/packages/interfold-contracts/artifacts/contracts/token/InterfoldTicketToken.sol/InterfoldTicketToken.json
+++ b/packages/interfold-contracts/artifacts/contracts/token/InterfoldTicketToken.sol/InterfoldTicketToken.json
@@ -1356,7 +1356,7 @@
   "linkReferences": {},
   "deployedLinkReferences": {},
   "immutableReferences": {
-    "4593": [
+    "4579": [
       {
         "length": 32,
         "start": 3079
@@ -1370,13 +1370,13 @@
         "start": 5499
       }
     ],
-    "7942": [
+    "7928": [
       {
         "length": 32,
         "start": 5951
       }
     ],
-    "7945": [
+    "7931": [
       {
         "length": 32,
         "start": 5996
@@ -1384,5 +1384,5 @@
     ]
   },
   "inputSourceName": "project/contracts/token/InterfoldTicketToken.sol",
-  "buildInfoId": "solc-0_8_28-333bedd9b9edefb785c3ddd79bdef9ffb671c898"
+  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
 }

--- a/packages/interfold-contracts/artifacts/contracts/token/InterfoldTicketToken.sol/InterfoldTicketToken.json
+++ b/packages/interfold-contracts/artifacts/contracts/token/InterfoldTicketToken.sol/InterfoldTicketToken.json
@@ -1384,5 +1384,5 @@
     ]
   },
   "inputSourceName": "project/contracts/token/InterfoldTicketToken.sol",
-  "buildInfoId": "solc-0_8_28-0ca50e7a3146885cb71e22b8933a83860bcf30a5"
+  "buildInfoId": "solc-0_8_28-2b81250fa70db71411b93f5a8b500b9b1614b38b"
 }

--- a/packages/interfold-contracts/contracts/interfaces/IBondingRegistry.sol
+++ b/packages/interfold-contracts/contracts/interfaces/IBondingRegistry.sol
@@ -36,6 +36,9 @@ interface IBondingRegistry {
     ///         zero license-token placeholder used during circular deployment).
     error InvalidBondingAsset(address asset);
 
+    /// @notice The configured license token does not provide a valid locked balance.
+    error IncompatibleLicenseToken(address token);
+
     /// @notice A bonding asset cannot rotate while balances remain denominated in it.
     error OutstandingAssetLiabilities(address asset, uint256 amount);
 
@@ -627,7 +630,8 @@ interface IBondingRegistry {
     /**
      * @notice Set license token
      * @param newLicenseToken New license token
-     * @dev Only callable by contract owner
+     * @dev Only callable by contract owner. A nonzero token must implement
+     *      `ILockAwareLicenseToken.lockedBalanceOf`.
      */
     function setLicenseToken(IERC20 newLicenseToken) external;
 

--- a/packages/interfold-contracts/contracts/interfaces/ICiphernodeRegistry.sol
+++ b/packages/interfold-contracts/contracts/interfaces/ICiphernodeRegistry.sol
@@ -380,11 +380,14 @@ interface ICiphernodeRegistry {
     //                                                        //
     ////////////////////////////////////////////////////////////
 
-    /// @notice Check if a ciphernode is eligible for committee selection
-    /// @dev A ciphernode is eligible if it is enabled in the registry and meets bonding requirements
+    /// @notice Check current global eligibility for future committee selection.
+    /// @dev This view uses the current bonding registry. E3 ticket validation
+    ///      uses the bonding registry saved for that E3.
     /// @param ciphernode Address of the ciphernode to check
     /// @return eligible Whether the ciphernode is eligible for committee selection
-    function isCiphernodeEligible(address ciphernode) external returns (bool);
+    function isCiphernodeEligible(
+        address ciphernode
+    ) external view returns (bool);
 
     /// @notice Check if a ciphernode is enabled in the registry
     /// @param node Address of the ciphernode

--- a/packages/interfold-contracts/contracts/interfaces/ICiphernodeRegistry.sol
+++ b/packages/interfold-contracts/contracts/interfaces/ICiphernodeRegistry.sol
@@ -341,9 +341,6 @@ interface ICiphernodeRegistry {
     /// @notice Caller is not the Interfold contract
     error OnlyInterfold();
 
-    /// @notice Caller is not the bonding registry
-    error OnlyBondingRegistry();
-
     /// @notice Caller is neither owner nor bonding registry
     error NotOwnerOrBondingRegistry();
 

--- a/packages/interfold-contracts/contracts/registry/BondingRegistry.sol
+++ b/packages/interfold-contracts/contracts/registry/BondingRegistry.sol
@@ -642,7 +642,7 @@ contract BondingRegistry is
     function bondLicenseFor(
         address operator,
         uint256 amount
-    ) external nonReentrant noExitInProgress(operator) onlyBondOwner(operator) {
+    ) external nonReentrant noExitInProgress(operator) {
         _bondLicense(operator, amount);
     }
 
@@ -1153,7 +1153,7 @@ contract BondingRegistry is
         require(amount != 0, ZeroAmount());
 
         address bondOwner = bondOwnerOf(operator);
-        require(bondOwner != address(0), NotBondOwner(msg.sender, operator));
+        require(msg.sender == bondOwner, NotBondOwner(msg.sender, operator));
 
         operators[operator].licenseBond += amount;
         _bondedByOwner[bondOwner] += amount;

--- a/packages/interfold-contracts/contracts/registry/BondingRegistry.sol
+++ b/packages/interfold-contracts/contracts/registry/BondingRegistry.sol
@@ -471,9 +471,10 @@ contract BondingRegistry is
         if (delegatedBond != 0) {
             uint256 remainingBonded = _bondedByOwner[previousOwner] -
                 delegatedBond;
-            uint256 lockedBalance = ILockAwareLicenseToken(
-                address(licenseToken)
-            ).lockedBalanceOf(previousOwner);
+            uint256 lockedBalance = _lockedBalanceOf(
+                licenseToken,
+                previousOwner
+            );
             uint256 controlledBalance = licenseToken.balanceOf(previousOwner) +
                 remainingBonded;
             if (lockedBalance > controlledBalance) {
@@ -1011,6 +1012,9 @@ contract BondingRegistry is
                 );
             }
         }
+        if (next != address(0)) {
+            _lockedBalanceOf(newLicenseToken, address(this));
+        }
         licenseToken = newLicenseToken;
         emit LicenseTokenSet(next);
     }
@@ -1228,6 +1232,21 @@ contract BondingRegistry is
             if (abi.decode(result, (uint256)) != 0) return true;
         }
         return false;
+    }
+
+    /// @dev Reads a lock-aware token through a checked low-level call so a bad
+    ///      configuration returns a protocol error instead of an ABI decode error.
+    function _lockedBalanceOf(
+        IERC20 token,
+        address account
+    ) internal view returns (uint256) {
+        (bool success, bytes memory result) = address(token).staticcall(
+            abi.encodeCall(ILockAwareLicenseToken.lockedBalanceOf, (account))
+        );
+        if (!success || result.length != 32) {
+            revert IncompatibleLicenseToken(address(token));
+        }
+        return abi.decode(result, (uint256));
     }
 
     /// @dev Calculates the minimum license bond required to maintain active status.

--- a/packages/interfold-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/interfold-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -784,6 +784,7 @@ contract CiphernodeRegistryOwnable is
     }
 
     /// @inheritdoc ICiphernodeRegistry
+    /// @dev This global view does not predict ticket acceptance for an existing E3.
     function isCiphernodeEligible(address node) public view returns (bool) {
         if (!isEnabled(node)) return false;
 
@@ -1055,13 +1056,12 @@ contract CiphernodeRegistryOwnable is
 
         Committee storage c = committees[e3Id];
 
-        // bind ticket weight to the request-time snapshot via the
-        // ticket token's EIP-6372 ERC20Votes checkpoints. The outer
-        // `isCiphernodeEligible(msg.sender)` check in {submitTicket} still
-        // gates on the operator's *current* `isActive` flag, but the score
-        // and selection weight below derive purely from the historical
-        // ticket balance at `c.requestBlock - 1`, so churn between request
-        // time and the ticket submission window cannot inflate weights.
+        // Bind ticket weight to the request-time snapshot through the ticket
+        // token's EIP-6372 ERC20Votes checkpoints. {submitTicket} uses this
+        // E3's saved bonding registry for the current `isActive` check. The
+        // score and selection weight below use only the historical ticket
+        // balance at `c.requestBlock - 1`. Later balance changes cannot
+        // increase the saved weight.
         uint256 ticketBalance = e3Bonding.getTicketBalanceAtBlock(
             node,
             c.requestBlock - 1

--- a/packages/interfold-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/interfold-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -697,14 +697,11 @@ contract CiphernodeRegistryOwnable is
 
     /// @notice Update the registry-wide vote validity window used by accusers
     ///         when stamping `AccusationVote.deadline`.
-    /// @dev Ciphernodes fetch this once at startup. After a change, in-flight
-    ///      ciphernode processes continue to use the previous value until
-    ///      restarted — operators should coordinate a restart if the new
-    ///      window is materially shorter than the old one, otherwise stale
-    ///      nodes will produce votes the on-chain verifier rejects.
-    /// @param _accusationVoteValidity New validity window in seconds.
-    ///        Zero is allowed and intentionally disables slashing submission
-    ///        until governance restores a nonzero value.
+    /// @dev Ciphernodes fetch this value at startup. Operators must restart
+    ///      nodes after a change. Otherwise, nodes can create vote deadlines
+    ///      that the on-chain verifier rejects.
+    /// @param _accusationVoteValidity New nonzero validity window in seconds.
+    ///        Use the proposal and commit functions to set a zero value.
     function setAccusationVoteValidity(
         uint256 _accusationVoteValidity
     ) external onlyOwner {
@@ -716,8 +713,8 @@ contract CiphernodeRegistryOwnable is
         emit AccusationVoteValiditySet(_accusationVoteValidity);
     }
 
-    /// @notice Propose a new accusation vote validity window (supports zero).
-    /// @dev Zeroing the window is slash-disable behavior and therefore timelocked.
+    /// @notice Propose a new accusation vote validity window. Zero is permitted.
+    /// @dev A zero value disables slash submission after the time delay.
     function proposeAccusationVoteValidity(
         uint256 _accusationVoteValidity
     ) external onlyOwner {

--- a/packages/interfold-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
+++ b/packages/interfold-contracts/contracts/registry/CiphernodeRegistryOwnable.sol
@@ -192,12 +192,6 @@ contract CiphernodeRegistryOwnable is
         _;
     }
 
-    /// @dev Restricts function access to only the bonding registry
-    modifier onlyBondingRegistry() {
-        require(msg.sender == address(bondingRegistry), OnlyBondingRegistry());
-        _;
-    }
-
     /// @dev Restricts function access to owner or bonding registry
     modifier onlyOwnerOrBondingVault() {
         require(

--- a/packages/interfold-contracts/contracts/test/MockLockAwareLicenseToken.sol
+++ b/packages/interfold-contracts/contracts/test/MockLockAwareLicenseToken.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+pragma solidity 0.8.28;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockLockAwareLicenseToken is ERC20 {
+    enum ResponseMode {
+        Valid,
+        Revert,
+        Malformed
+    }
+
+    ResponseMode public responseMode;
+
+    constructor(ResponseMode mode) ERC20("Lock-aware license", "LOCK") {
+        responseMode = mode;
+    }
+
+    function setResponseMode(ResponseMode mode) external {
+        responseMode = mode;
+    }
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+
+    function lockedBalanceOf(address) external view returns (uint256) {
+        if (responseMode == ResponseMode.Revert) {
+            revert("locked balance unavailable");
+        }
+        if (responseMode == ResponseMode.Malformed) {
+            assembly ("memory-safe") {
+                mstore(0, 0)
+                return(0, 31)
+            }
+        }
+        return 0;
+    }
+}

--- a/packages/interfold-contracts/test/Registry/BondingRegistry.spec.ts
+++ b/packages/interfold-contracts/test/Registry/BondingRegistry.spec.ts
@@ -1715,6 +1715,83 @@ describe("BondingRegistry", function () {
       ).to.be.revertedWithCustomError(bondingRegistry, "InvalidConfiguration");
     });
 
+    describe("setLicenseToken()", function () {
+      it("requires a valid locked-balance response", async function () {
+        const { bondingRegistry, usdcToken } = await loadFixture(setup);
+        const plainTokenAddress = await usdcToken.getAddress();
+
+        await expect(bondingRegistry.setLicenseToken(plainTokenAddress))
+          .to.be.revertedWithCustomError(
+            bondingRegistry,
+            "IncompatibleLicenseToken",
+          )
+          .withArgs(plainTokenAddress);
+
+        const token = await (
+          await ethers.getContractFactory("MockLockAwareLicenseToken")
+        ).deploy(1);
+        const tokenAddress = await token.getAddress();
+
+        await expect(bondingRegistry.setLicenseToken(tokenAddress))
+          .to.be.revertedWithCustomError(
+            bondingRegistry,
+            "IncompatibleLicenseToken",
+          )
+          .withArgs(tokenAddress);
+
+        await token.setResponseMode(2);
+        await expect(bondingRegistry.setLicenseToken(tokenAddress))
+          .to.be.revertedWithCustomError(
+            bondingRegistry,
+            "IncompatibleLicenseToken",
+          )
+          .withArgs(tokenAddress);
+
+        await token.setResponseMode(0);
+        await expect(bondingRegistry.setLicenseToken(tokenAddress))
+          .to.emit(bondingRegistry, "LicenseTokenSet")
+          .withArgs(tokenAddress);
+      });
+
+      it("reports a lock-aware token that later stops responding", async function () {
+        const {
+          bondingRegistry,
+          operator1,
+          operator2,
+          operator1Address,
+          operator2OwnerAddress,
+        } = await loadFixture(setup);
+        const token = await (
+          await ethers.getContractFactory("MockLockAwareLicenseToken")
+        ).deploy(0);
+        const tokenAddress = await token.getAddress();
+        const bondAmount = LICENSE_REQUIRED_BOND;
+
+        await bondingRegistry.setLicenseToken(tokenAddress);
+        await token.mint(await operator1.getAddress(), bondAmount);
+        await token.connect(operator1).getFunction("approve")(
+          await bondingRegistry.getAddress(),
+          bondAmount,
+        );
+        await bondingRegistry
+          .connect(operator1)
+          .bondLicenseFor(operator1Address, bondAmount);
+        await bondingRegistry
+          .connect(operator1)
+          .proposeBondOwner(operator1Address, operator2OwnerAddress);
+
+        await token.setResponseMode(1);
+        await expect(
+          bondingRegistry.connect(operator2).acceptBondOwner(operator1Address),
+        )
+          .to.be.revertedWithCustomError(
+            bondingRegistry,
+            "IncompatibleLicenseToken",
+          )
+          .withArgs(tokenAddress);
+      });
+    });
+
     describe("withdrawSlashedFunds()", function () {
       it("allows owner to withdraw slashed funds", async function () {
         const { bondingRegistry, treasury } = await loadFixture(setup);
@@ -2162,7 +2239,7 @@ describe("BondingRegistry", function () {
       expect(await bondingRegistry.totalLicenseLiability()).to.equal(0);
 
       const replacement = await (
-        await ethers.getContractFactory("MockFeeOnTransferToken")
+        await ethers.getContractFactory("MockLockAwareLicenseToken")
       ).deploy(0);
       await expect(
         bondingRegistry.setLicenseToken(await replacement.getAddress()),

--- a/packages/interfold-contracts/test/Registry/BondingRegistry.spec.ts
+++ b/packages/interfold-contracts/test/Registry/BondingRegistry.spec.ts
@@ -523,6 +523,25 @@ describe("BondingRegistry", function () {
       ).to.be.revertedWithCustomError(bondingRegistry, "ZeroAmount");
     });
 
+    it("enforces bond-owner authorization inside the accounting path", async function () {
+      const { bondingRegistry, notTheOwner } = await loadFixture(setup);
+      const caller = await notTheOwner.getAddress();
+
+      await expect(
+        bondingRegistry
+          .connect(notTheOwner)
+          .bondLicenseFor(operator1Address, LICENSE_REQUIRED_BOND),
+      )
+        .to.be.revertedWithCustomError(bondingRegistry, "NotBondOwner")
+        .withArgs(caller, operator1Address);
+
+      await expect(
+        bondingRegistry
+          .connect(notTheOwner)
+          .bondLicenseFor(ethers.ZeroAddress, LICENSE_REQUIRED_BOND),
+      ).to.be.revertedWithCustomError(bondingRegistry, "ZeroAddress");
+    });
+
     it("reverts if exit is in progress", async function () {
       const { bondingRegistry, licenseToken, operator1 } =
         await loadFixture(setup);


### PR DESCRIPTION
Fixes the following Zenith issues:

- https://github.com/zenith-security/2026-07-interfold/issues/50
- https://github.com/zenith-security/2026-07-interfold/issues/51
- https://github.com/zenith-security/2026-07-interfold/issues/52
- https://github.com/zenith-security/2026-07-interfold/issues/54
- https://github.com/zenith-security/2026-07-interfold/issues/56
- https://github.com/zenith-security/2026-07-interfold/issues/57

This centralizes license-bond authorization, removes the unused registry guard, corrects the vote and eligibility documentation, preserves reward credits in the dashboard, and validates replacement license tokens before they are configured.

Tested with the BondingRegistry and dashboard test suites, contract compilation, upgrade validation, contract size checks, formatting, lint, documentation checks, and invariant checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation to ensure replacement license tokens support reliable locked-balance checks.
  - Improved reward tracking and claims, including split allocations and exact aggregate matching.
  - E3 ticket eligibility now uses the bonding registry snapshot captured at request time.

- **Bug Fixes**
  - Strengthened bond-owner authorization during license bonding.
  - Invalid, mismatched, or malformed reward data is now safely rejected.
  - Ciphernode eligibility checks are read-only and reflect current eligibility.

- **Tests**
  - Added coverage for token compatibility, authorization, reward allocation, claim scenarios, and malformed reward events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->