### PR TITLE
docs: align tokenomics figures with allocation sheet

### DIFF
--- a/docs/components/Tokenomics/index.tsx
+++ b/docs/components/Tokenomics/index.tsx
@@ -30,23 +30,24 @@ type Slice = {
 // Community = vivid brand greens; Other = dark brand neutrals.
 // Colors alternate light↔dark across stacking order for maximum area-chart legibility.
 const ALLOCATION: Slice[] = [
-  // Community (52%)
-  { key: 'Foundation Treasury', pct: 41.4469, displayPct: 41.5, color: '#3A7D44', group: 'community' }, // vivid forest
-  { key: 'Unsold CCA Tokens', pct: 6.3615, displayPct: 6.5, color: '#687d71', group: 'community' }, // brand sage
+  // Community (51.81%)
+  { key: 'Foundation Treasury', pct: 41.4469, color: '#3A7D44', group: 'community' }, // vivid forest
+  { key: 'Unsold CCA Tokens', pct: 6.3615, displayPct: 6.36, color: '#687d71', group: 'community' }, // brand sage
   { key: 'Airdrop', pct: 4, color: '#82F5AD', group: 'community' }, // brand bright mint
-  // Other (48%)
+  // Other (48.19%)
   { key: 'Gnosis Guild', pct: 20, color: '#252525', group: 'other' }, // brand dark charcoal
   { key: 'Investors', pct: 19.1916, color: '#3A4E42', group: 'other' }, // dark muted forest
   { key: 'Team and Advisors', pct: 9, color: '#8FAE96', group: 'other' }, // muted sage
 ]
 
 // Ceilings rather than fixed amounts, so their share is shown as "at most".
-const UP_TO = new Set(['Unsold CCA Tokens'])
+// These are the categories the allocation sheet marks "up to".
+const UP_TO = new Set(['Airdrop', 'Unsold CCA Tokens'])
 
 const communitySlices = ALLOCATION.filter((d) => d.group === 'community')
 const otherSlices = ALLOCATION.filter((d) => d.group === 'other')
-const COMMUNITY_PCT = communitySlices.reduce((s, d) => s + d.pct, 0) // 52
-const OTHER_PCT = otherSlices.reduce((s, d) => s + d.pct, 0) // 48
+const COMMUNITY_PCT = communitySlices.reduce((s, d) => s + d.pct, 0) // 51.8084
+const OTHER_PCT = otherSlices.reduce((s, d) => s + d.pct, 0) // 48.1916
 
 const COLOR_BY_KEY: Record<string, string> = Object.fromEntries(ALLOCATION.map((s) => [s.key, s.color]))
 
@@ -59,15 +60,22 @@ const GROUP_COLOR: Record<Group, string> = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-// Percentages display as whole numbers. Exact values are kept in ALLOCATION so
-// the donut geometry stays true; only the printed figures are rounded.
-const fmtPct = (n: number) => `${Math.round(n)}%`
+const round2 = (n: number) => Math.round(n * 100) / 100
+const ceil2 = (n: number) => Math.ceil(n * 100) / 100
+
+// Percentages display to two decimal places, whole numbers included, so the
+// column reads as one aligned set of figures. Exact values are kept in
+// ALLOCATION so the donut geometry stays true; only the printed figures are
+// rounded.
+const fmtNum = (n: number) => n.toFixed(2)
+
+const fmtPct = (n: number) => `${fmtNum(round2(n))}%`
 
 // Slice shares honour displayPct when set. Without one, a ceiling rounds up so
-// the printed figure stays a true bound: 6.3615% shown as "≤ 6%" would be false.
+// the printed figure stays a true bound.
 const fmtShare = (d: Slice) => {
-  const v = d.displayPct ?? (UP_TO.has(d.key) ? Math.ceil(d.pct) : Math.round(d.pct))
-  return `${UP_TO.has(d.key) ? '≤ ' : ''}${Number.isInteger(v) ? v : v.toFixed(1)}%`
+  const v = d.displayPct ?? (UP_TO.has(d.key) ? ceil2(d.pct) : round2(d.pct))
+  return `${UP_TO.has(d.key) ? '≤ ' : ''}${fmtNum(v)}%`
 }
 
 function polar(cx: number, cy: number, r: number, angleDeg: number): [number, number] {
@@ -97,7 +105,7 @@ function donutSlice(cx: number, cy: number, rOuter: number, rInner: number, star
 export function KeyParameters() {
   const cards = [
     { label: 'Total Supply', value: '1.2B' },
-    { label: 'Circulating Supply at TGE', value: '≤ 28%' },
+    { label: 'Circulating Supply at TGE', value: '≤ 27.37%' },
   ]
   return (
     <div className={classes.stats}>
@@ -119,9 +127,9 @@ export function KeyParameters() {
 // so the two colour families read as distinct visual clusters.
 const GROUP_GAP_DEG = 6
 const TOTAL_SLICE_DEG = 360 - 2 * GROUP_GAP_DEG // 348°
-const COMMUNITY_SPAN_DEG = (COMMUNITY_PCT / 100) * TOTAL_SLICE_DEG // ≈ 198.36°
-const OTHER_SPAN_DEG = (OTHER_PCT / 100) * TOTAL_SLICE_DEG // ≈ 149.64°
-const OTHER_START_DEG = COMMUNITY_SPAN_DEG + GROUP_GAP_DEG // ≈ 204.36°
+const COMMUNITY_SPAN_DEG = (COMMUNITY_PCT / 100) * TOTAL_SLICE_DEG // ≈ 180.29°
+const OTHER_SPAN_DEG = (OTHER_PCT / 100) * TOTAL_SLICE_DEG // ≈ 167.71°
+const OTHER_START_DEG = COMMUNITY_SPAN_DEG + GROUP_GAP_DEG // ≈ 186.29°
 
 export function AllocationPie() {
   const size = 260


### PR DESCRIPTION
Reconciles the tokenomics page against the **FOLD Token Allocation & Unlocks** sheet.

No allocation data changed — the underlying percentages and token amounts already matched the sheet exactly. This corrects how those figures are *displayed*.

## Changes

| | Before | After |
|---|---|---|
| Circulating Supply at TGE | ≤ 28% | **≤ 27.37%** |
| Foundation Treasury | 41.5% | **41.45%** |
| Unsold CCA Tokens | ≤ 6.5% | **≤ 6.36%** |
| Airdrop | 4% | **≤ 4.00%** |
| Investors | 19% | **19.19%** |
| Gnosis Guild | 20% | **20.00%** |
| Team and Advisors | 9% | **9.00%** |
| Community / Other | 52% / 48% | **51.81% / 48.19%** |

- All shares now print to two decimal places, so the column reads as one aligned set rather than a mix of rounded and exact values. Group subtotals moved to 2dp too, so they add up to the rows above them.
- `Airdrop` added to the `UP_TO` set — the sheet marks it "up to", exactly as it marks Unsold CCA Tokens.
- Circulating supply at TGE now uses the sheet's exact figure (27.3749%) rather than the looser ≤ 28% bound.
- Fixed donut-geometry comments left stale by the earlier 57/43 split.

## Verification against the sheet

- All six allocations match to full sheet precision (Investors 19.191603%, Treasury 41.446892%, Unsold CCA 6.361505%); sum to 100%.
- All six token amounts match; sum to exactly 1,200,000,000.
- All vesting periods, cliffs, and monthly unlock amounts match.
- **Circulating-supply curve matches the sheet at 0.000000pp deviation across all 48 months.**

## Note for reviewers

The **Aragon bridge** round ($250k at $25.8m valuation, 11,601,919 tokens) appears in the sheet but not in the fundraising list on the page. Its tokens are already counted inside Investors 19.19%, so nothing on the page is inaccurate — flagging only in case the omission should be revisited. Left unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Refined Tokenomics allocation figures to include Airdrop amounts in capped categories.
  - Improved allocation accuracy by using precise community and other totals.
  - Updated percentage displays to show two decimal places and ceiling-based capped values.
  - Updated the circulating supply at TGE card to display `≤ 27.37%`.
  - Adjusted donut chart proportions to reflect precise allocation totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->