### PR TITLE
chore: timestamp/block number fix

### DIFF
--- a/examples/CRISP/server/src/server/indexer.rs
+++ b/examples/CRISP/server/src/server/indexer.rs
@@ -204,7 +204,7 @@ pub async fn register_e3_requested(
                                 credits_u256
                             )
                             .await
-                            .map_err(|e| eyre::eyre!("Etherscan error: {}", e))?
+                            .context("Etherscan token-holder discovery failed")?
                         }
                         CreditMode::Custom => {
                             etherscan_client
@@ -223,7 +223,7 @@ pub async fn register_e3_requested(
                                 )?,
                             )
                             .await
-                            .map_err(|e| eyre::eyre!("Etherscan error: {}", e))?
+                            .context("Etherscan token-holder discovery failed")?
                         }
                     }
                 };

--- a/examples/CRISP/server/src/server/indexer.rs
+++ b/examples/CRISP/server/src/server/indexer.rs
@@ -115,9 +115,14 @@ pub async fn register_e3_requested(
 
                 let input_window = [e3.inputWindow[0].to::<u64>(), e3.inputWindow[1].to::<u64>()];
 
-                // The census is built at the block before the request, as the request block
+                // The census is built one tick before the request, as the request timepoint
                 // itself is not final when the E3 is requested.
-                let snapshot_block = event.e3.requestBlock.to::<u64>().saturating_sub(1);
+                //
+                // `requestBlock` is a timestamp, not a block height — the ticket token runs
+                // an EIP-6372 `mode=timestamp` clock, and `Interfold.request` assigns
+                // `block.timestamp` to match the checkpoints it is compared against. The
+                // name is historical.
+                let snapshot_timepoint = event.e3.requestBlock.to::<u64>().saturating_sub(1);
 
                 // Get token holders from Etherscan API or mocked data.
                 // Asked only when the round declared it. Probing every requester and falling back
@@ -194,7 +199,7 @@ pub async fn register_e3_requested(
                             etherscan_client
                             .get_token_holders_with_constant_balance(
                                 token_address,
-                                snapshot_block,
+                                snapshot_timepoint,
                                 credits_u256
                             )
                             .await
@@ -204,7 +209,7 @@ pub async fn register_e3_requested(
                             etherscan_client
                             .get_token_holders_with_voting_power(
                                 token_address,
-                                snapshot_block,
+                                snapshot_timepoint,
                                 &CONFIG.http_rpc_url,
                                 U256::from_str_radix(&balance_threshold.to_string(), 10).map_err(
                                     |e| {
@@ -235,7 +240,7 @@ pub async fn register_e3_requested(
                     custom_params,
                     e3.requester.to_string(),
                     input_window[1],
-                    snapshot_block,
+                    snapshot_timepoint,
                 )
                 .await?;
 

--- a/examples/CRISP/server/src/server/indexer.rs
+++ b/examples/CRISP/server/src/server/indexer.rs
@@ -200,6 +200,7 @@ pub async fn register_e3_requested(
                             .get_token_holders_with_constant_balance(
                                 token_address,
                                 snapshot_timepoint,
+                                &CONFIG.http_rpc_url,
                                 credits_u256
                             )
                             .await

--- a/examples/CRISP/server/src/server/models.rs
+++ b/examples/CRISP/server/src/server/models.rs
@@ -172,9 +172,10 @@ pub struct E3StateLite {
 
     pub start_time: u64,
     pub end_time: u64,
-    /// The block the E3 was requested at
+    /// The EIP-6372 timepoint (timestamp) the E3 was requested at
     pub start_block: u64,
-    /// The block the census was built at
+    /// The EIP-6372 timepoint (timestamp) the census was built at. Named for a block
+    /// height for backwards compatibility with stored rounds and the web API.
     pub snapshot_block: u64,
 
     pub committee_public_key: Vec<u8>,
@@ -243,8 +244,9 @@ pub struct E3Crisp {
     pub num_options: String,
     pub credit_mode: CreditMode,
     pub credits: Option<String>,
-    /// The block the census was built at. Defaults to 0 for rounds stored before
-    /// this field existed, which is resolved when the round state is read.
+    /// The EIP-6372 timepoint (timestamp) the census was built at. Defaults to 0 for
+    /// rounds stored before this field existed, which is resolved when the round state
+    /// is read. Named for a block height for backwards compatibility.
     #[serde(default)]
     pub snapshot_block: u64,
 }
@@ -336,5 +338,4 @@ mod census_mode_tests {
         assert_eq!(CensusMode::try_from(0u64).unwrap(), CensusMode::Token);
         assert_eq!(CensusMode::try_from(1u64).unwrap(), CensusMode::ByRequester);
     }
-
 }

--- a/examples/CRISP/server/src/server/token_holders/etherscan.rs
+++ b/examples/CRISP/server/src/server/token_holders/etherscan.rs
@@ -208,6 +208,65 @@ impl EtherscanClient {
         Ok(block_number)
     }
 
+    /// Fetch one page of Etherscan results, surfacing in-band API errors.
+    ///
+    /// Etherscan reports failures with HTTP 200, `status: "0"`, and the explanation in
+    /// `result` as a bare string rather than the success type. Deserializing the body
+    /// straight into `T` therefore collapses every API error — invalid key, rate limit,
+    /// Pro-only endpoint — into an indistinguishable decode failure. The envelope is
+    /// inspected before `result` is typed, so the real message reaches the caller.
+    ///
+    /// Returns `Ok(None)` for the "No records found" response, which is a legitimate
+    /// empty result rather than an error.
+    async fn fetch_page<T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        what: &str,
+    ) -> Result<Option<T>> {
+        let body = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .with_context(|| format!("Failed to send {} request to Etherscan", what))?
+            .text()
+            .await
+            .with_context(|| format!("Failed to read {} response body", what))?;
+
+        let envelope: EtherscanResponse<serde_json::Value> = serde_json::from_str(&body)
+            .with_context(|| {
+                format!(
+                    "Failed to parse {} response envelope; body was: {}",
+                    what,
+                    body.chars().take(500).collect::<String>()
+                )
+            })?;
+
+        if envelope.status != "1" {
+            if envelope.message.eq_ignore_ascii_case("No records found") {
+                return Ok(None);
+            }
+
+            // The `result` field carries Etherscan's actual explanation; `message` is
+            // usually just "NOTOK".
+            let detail = match &envelope.result {
+                Some(serde_json::Value::String(s)) if !s.is_empty() => s.clone(),
+                _ => envelope.message.clone(),
+            };
+            return Err(eyre!("Etherscan {} request failed: {}", what, detail));
+        }
+
+        let result = match envelope.result {
+            Some(value) => value,
+            None => return Ok(None),
+        };
+
+        let typed = serde_json::from_value(result)
+            .with_context(|| format!("Failed to parse {} result payload", what))?;
+
+        Ok(Some(typed))
+    }
+
     /// Get transfer logs for a token
     pub async fn get_transfer_logs(
         &self,
@@ -227,32 +286,11 @@ impl EtherscanClient {
                 ETHERSCAN_API_URL, token, from_block, to_block, transfer_topic, page, self.chain_id, self.api_key
             );
 
-            let response = self
-                .client
-                .get(&url)
-                .send()
+            let logs: Vec<TransferLog> = match self
+                .fetch_page::<Vec<TransferLog>>(&url, "transfer logs")
                 .await
-                .context("Failed to fetch transfer logs")?;
-            let data: EtherscanResponse<Vec<TransferLog>> = response
-                .json()
-                .await
-                .context("Failed to parse transfer logs response")?;
-
-            // Break if request failed
-            if data.status != "1" {
-                if data.message.eq_ignore_ascii_case("No records found") {
-                    break;
-                }
-
-                return Err(eyre!(
-                    "Etherscan getLogs failed on page {}: {}",
-                    page,
-                    data.message
-                ));
-            }
-
-            // Break if no results
-            let logs = match data.result {
+                .with_context(|| format!("Transfer logs page {}", page))?
+            {
                 Some(logs) if !logs.is_empty() => logs,
                 _ => break,
             };
@@ -294,32 +332,11 @@ impl EtherscanClient {
                 ETHERSCAN_API_URL, token, from_block, to_block, delegate_votes_changed_topic, page, self.chain_id, self.api_key
             );
 
-            let response = self
-                .client
-                .get(&url)
-                .send()
+            let logs: Vec<DelegateVotesChangedLog> = match self
+                .fetch_page::<Vec<DelegateVotesChangedLog>>(&url, "delegation logs")
                 .await
-                .context("Failed to fetch delegation logs")?;
-            let data: EtherscanResponse<Vec<DelegateVotesChangedLog>> = response
-                .json()
-                .await
-                .context("Failed to parse delegation logs response")?;
-
-            // Break if request failed
-            if data.status != "1" {
-                if data.message.eq_ignore_ascii_case("No records found") {
-                    break;
-                }
-
-                return Err(eyre!(
-                    "Etherscan getLogs failed on page {}: {}",
-                    page,
-                    data.message
-                ));
-            }
-
-            // Break if no results
-            let logs = match data.result {
+                .with_context(|| format!("Delegation logs page {}", page))?
+            {
                 Some(logs) if !logs.is_empty() => logs,
                 _ => break,
             };

--- a/examples/CRISP/server/src/server/token_holders/etherscan.rs
+++ b/examples/CRISP/server/src/server/token_holders/etherscan.rs
@@ -94,6 +94,50 @@ impl EtherscanClient {
         }
     }
 
+    /// Resolve an EIP-6372 timestamp timepoint to the last block mined at or before it.
+    ///
+    /// The E3 census snapshot is a timepoint, not a block height: `InterfoldTicketToken`
+    /// reports `CLOCK_MODE() == "mode=timestamp"`, so `E3.requestBlock` holds a timestamp
+    /// despite its name. Log queries address blocks, so the timepoint must be converted
+    /// before it can bound a `getLogs` range.
+    ///
+    /// Uses `closest=before` so the range covers exactly the blocks that contribute to
+    /// voting power at the timepoint. On a chain where several blocks can share one
+    /// timestamp, this can end the range at the first of them.
+    pub async fn get_block_by_timestamp(&self, timestamp: u64) -> Result<u64> {
+        let url = format!(
+            "{}?module=block&action=getblocknobytime&timestamp={}&closest=before&chainid={}&apikey={}",
+            ETHERSCAN_API_URL, timestamp, self.chain_id, self.api_key
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to send block-by-timestamp request to Etherscan")?;
+        let data: EtherscanResponse<String> = response
+            .json()
+            .await
+            .context("Failed to parse block-by-timestamp response")?;
+
+        if data.status != "1" {
+            return Err(eyre!(
+                "Block for timestamp {} not found: {}",
+                timestamp,
+                data.message
+            ));
+        }
+
+        let block_number = data
+            .result
+            .ok_or_else(|| eyre!("No block data found for timestamp {}", timestamp))?;
+
+        block_number
+            .parse::<u64>()
+            .with_context(|| format!("Failed to parse block number {}", block_number))
+    }
+
     /// Get the deployment block number for a contract
     pub async fn get_deployment_block(&self, token: &str) -> Result<u64> {
         let url = format!(
@@ -309,12 +353,12 @@ impl EtherscanClient {
         potential_voters.into_values().collect()
     }
 
-    /// Verify voting power for multiple addresses
+    /// Verify voting power for multiple addresses at an EIP-6372 timepoint
     pub async fn verify_voting_power(
         &self,
         token_address: Address,
         potential_voters: &[PotentialVoter],
-        block_number: u64,
+        timepoint: u64,
         rpc_url: &str,
         threshold: U256,
     ) -> Result<Vec<TokenHolder>> {
@@ -328,7 +372,7 @@ impl EtherscanClient {
         let scale_factor = U256::from(10u128.pow(precision as u32));
 
         for voter in potential_voters {
-            match Self::get_past_votes(token_address, voter.address, block_number, rpc_url).await {
+            match Self::get_past_votes(token_address, voter.address, timepoint, rpc_url).await {
                 Ok(votes) => {
                     if votes >= threshold {
                         let scaled_votes = votes / scale_factor;
@@ -436,11 +480,11 @@ impl EtherscanClient {
         balances
     }
 
-    /// Verify actual voting power for an address at a specific block
+    /// Verify actual voting power for an address at an EIP-6372 timepoint
     async fn get_past_votes(
         token_address: Address,
         voter_address: Address,
-        block_number: u64,
+        timepoint: u64,
         rpc_url: &str,
     ) -> Result<U256> {
         let url = rpc_url.parse().context("Failed to parse RPC URL")?;
@@ -448,7 +492,7 @@ impl EtherscanClient {
         let token = ERC20Votes::new(token_address, provider);
 
         match token
-            .getPastVotes(voter_address, U256::from(block_number))
+            .getPastVotes(voter_address, U256::from(timepoint))
             .call()
             .await
         {
@@ -509,22 +553,36 @@ impl EtherscanClient {
         U256::from_str_radix(hex_data, 16).unwrap_or(U256::ZERO)
     }
 
-    /// Get all token holders with voting power at a specific block
+    /// Get all token holders with voting power at a census timepoint.
+    ///
+    /// `snapshot_timepoint` is an EIP-6372 timestamp, not a block height. Log discovery
+    /// needs the equivalent block, so both units are used: the block bounds the log
+    /// ranges, the timepoint is passed to `getPastVotes`.
     pub async fn get_token_holders_with_voting_power(
         &self,
         token_address: Address,
-        snapshot_block: u64,
+        snapshot_timepoint: u64,
         rpc_url: &str,
         threshold: U256,
     ) -> Result<Vec<TokenHolder>> {
         log::info!("Starting token holder discovery for {}", token_address);
 
-        // Step 1: Determine starting block
+        // Step 1: Determine the block range
         let start_block = self
             .get_deployment_block(&token_address.to_string())
             .await
             .context("Failed to get deployment block")?;
         log::info!("Token deployed at block: {}", start_block);
+
+        let snapshot_block = self
+            .get_block_by_timestamp(snapshot_timepoint)
+            .await
+            .context("Failed to resolve snapshot timepoint to a block")?;
+        log::info!(
+            "Snapshot timepoint {} resolves to block {}",
+            snapshot_timepoint,
+            snapshot_block
+        );
 
         // Step 2: Fetch transfer logs
         log::info!(
@@ -555,13 +613,17 @@ impl EtherscanClient {
         let potential_voters = self.get_potential_voters(&transfer_logs, &delegation_logs);
         log::info!("Found {} potential voters", potential_voters.len());
 
-        // Step 5: Verify actual voting power
-        log::info!("Verifying voting power at block {}...", snapshot_block);
+        // Step 5: Verify actual voting power, at the timepoint rather than the block —
+        // the token checkpoints on `mode=timestamp`.
+        log::info!(
+            "Verifying voting power at timepoint {}...",
+            snapshot_timepoint
+        );
         let token_holders = self
             .verify_voting_power(
                 token_address,
                 &potential_voters,
-                snapshot_block,
+                snapshot_timepoint,
                 rpc_url,
                 threshold,
             )
@@ -583,7 +645,7 @@ impl EtherscanClient {
     pub async fn get_token_holders_with_constant_balance(
         &self,
         token_address: Address,
-        snapshot_block: u64,
+        snapshot_timepoint: u64,
         balance: U256,
     ) -> Result<Vec<TokenHolder>> {
         log::info!(
@@ -591,12 +653,24 @@ impl EtherscanClient {
             token_address
         );
 
-        // Step 1: Determine starting block
+        // Step 1: Determine the block range
         let start_block = self
             .get_deployment_block(&token_address.to_string())
             .await
             .context("Failed to get deployment block")?;
         log::info!("Token deployed at block: {}", start_block);
+
+        // Eligibility here rests on the logs alone — no `getPastVotes` pass narrows the
+        // set afterwards — so the range must not reach past the census timepoint.
+        let snapshot_block = self
+            .get_block_by_timestamp(snapshot_timepoint)
+            .await
+            .context("Failed to resolve snapshot timepoint to a block")?;
+        log::info!(
+            "Snapshot timepoint {} resolves to block {}",
+            snapshot_timepoint,
+            snapshot_block
+        );
 
         // Step 2: Fetch transfer logs
         log::info!(
@@ -953,14 +1027,40 @@ mod tests {
         let api_key = &CONFIG.etherscan_api_key;
         let rpc_url = &CONFIG.http_rpc_url;
         let threshold = U256::ZERO;
-        let snapshot_block = 9564734;
+        // A timepoint, matching what `E3.requestBlock` carries — not a block height.
+        let snapshot_timepoint = 1761201108;
 
         let client = EtherscanClient::new(api_key.to_string(), chain_id);
         let res = client
-            .get_token_holders_with_voting_power(token_address, snapshot_block, rpc_url, threshold)
+            .get_token_holders_with_voting_power(
+                token_address,
+                snapshot_timepoint,
+                rpc_url,
+                threshold,
+            )
             .await
             .unwrap();
 
         assert!(res.len() == 2);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_block_by_timestamp() {
+        let chain_id = CONFIG.chain_id;
+        let api_key = &CONFIG.etherscan_api_key;
+        let client = EtherscanClient::new(api_key.to_string(), chain_id);
+
+        // A timepoint of the size `E3.requestBlock` carries. Read as a block height it
+        // is far beyond any chain head, which is the failure this resolver removes.
+        let snapshot_timepoint = 1761201108;
+
+        let block = client
+            .get_block_by_timestamp(snapshot_timepoint)
+            .await
+            .unwrap();
+
+        assert!(block > 0);
+        assert!(block < snapshot_timepoint);
     }
 }

--- a/examples/CRISP/server/src/server/token_holders/etherscan.rs
+++ b/examples/CRISP/server/src/server/token_holders/etherscan.rs
@@ -5,8 +5,9 @@
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
 use crate::server::models::TokenHolder;
+use alloy::eips::BlockNumberOrTag;
 use alloy::primitives::{Address, U256};
-use alloy::providers::ProviderBuilder;
+use alloy::providers::{Provider, ProviderBuilder};
 use alloy::sol;
 use eyre::{eyre, Context, Result}; // Add this import
 use reqwest;
@@ -106,48 +107,64 @@ impl EtherscanClient {
         }
     }
 
-    /// Resolve an EIP-6372 timestamp timepoint to the last block mined at or before it.
+    /// Resolve an EIP-6372 timestamp timepoint to the highest block mined at or before it.
     ///
-    /// The E3 census snapshot is a timepoint, not a block height: `InterfoldTicketToken`
-    /// reports `CLOCK_MODE() == "mode=timestamp"`, so `E3.requestBlock` holds a timestamp
-    /// despite its name. Log queries address blocks, so the timepoint must be converted
-    /// before it can bound a `getLogs` range.
+    /// The E3 census snapshot is a timepoint, not a block height: `Interfold.request`
+    /// assigns `block.timestamp` to `E3.requestBlock` regardless of the census token.
+    /// Log queries address blocks, so the timepoint must be converted before it can
+    /// bound a `getLogs` range.
     ///
-    /// Uses `closest=before` so the range covers exactly the blocks that contribute to
-    /// voting power at the timepoint. On a chain where several blocks can share one
-    /// timestamp, this can end the range at the first of them.
-    pub async fn get_block_by_timestamp(&self, timestamp: u64) -> Result<u64> {
-        let url = format!(
-            "{}?module=block&action=getblocknobytime&timestamp={}&closest=before&chainid={}&apikey={}",
-            ETHERSCAN_API_URL, timestamp, self.chain_id, self.api_key
-        );
+    /// Resolved over RPC by binary search rather than through Etherscan's
+    /// `getblocknobytime`, which is a Pro-tier endpoint and fails on free API keys.
+    /// The search also pins the boundary exactly — the greatest block whose timestamp
+    /// is `<= timestamp`, including every block that contributes to voting power at the
+    /// timepoint and none that follow it.
+    pub async fn get_block_by_timestamp(timestamp: u64, rpc_url: &str) -> Result<u64> {
+        let url = rpc_url.parse().context("Failed to parse RPC URL")?;
+        let provider = ProviderBuilder::new().connect_http(url);
 
-        let response = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .context("Failed to send block-by-timestamp request to Etherscan")?;
-        let data: EtherscanResponse<String> = response
-            .json()
-            .await
-            .context("Failed to parse block-by-timestamp response")?;
+        let block_timestamp = |number: u64| {
+            let provider = provider.clone();
+            async move {
+                provider
+                    .get_block_by_number(BlockNumberOrTag::Number(number))
+                    .await
+                    .with_context(|| format!("Failed to fetch block {}", number))?
+                    .map(|block| block.header.timestamp)
+                    .ok_or_else(|| eyre!("Block {} not found", number))
+            }
+        };
 
-        if data.status != "1" {
+        let latest = provider
+            .get_block_number()
+            .await
+            .context("Failed to fetch latest block number")?;
+
+        // A timepoint at or beyond the head means the whole chain qualifies. This is
+        // reachable normally: the census is built moments after the request is mined.
+        if block_timestamp(latest).await? <= timestamp {
+            return Ok(latest);
+        }
+
+        if block_timestamp(0).await? > timestamp {
             return Err(eyre!(
-                "Block for timestamp {} not found: {}",
-                timestamp,
-                data.message
+                "Timestamp {} predates the genesis block; it is not a valid timepoint",
+                timestamp
             ));
         }
 
-        let block_number = data
-            .result
-            .ok_or_else(|| eyre!("No block data found for timestamp {}", timestamp))?;
+        // Invariant: `lo` is always at or before the timepoint, `hi` always after it.
+        let (mut lo, mut hi) = (0u64, latest);
+        while hi - lo > 1 {
+            let mid = lo + (hi - lo) / 2;
+            if block_timestamp(mid).await? <= timestamp {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
 
-        block_number
-            .parse::<u64>()
-            .with_context(|| format!("Failed to parse block number {}", block_number))
+        Ok(lo)
     }
 
     /// Get the deployment block number for a contract
@@ -617,8 +634,7 @@ impl EtherscanClient {
             .context("Failed to get deployment block")?;
         log::info!("Token deployed at block: {}", start_block);
 
-        let snapshot_block = self
-            .get_block_by_timestamp(snapshot_timepoint)
+        let snapshot_block = Self::get_block_by_timestamp(snapshot_timepoint, rpc_url)
             .await
             .context("Failed to resolve snapshot timepoint to a block")?;
         log::info!(
@@ -696,6 +712,7 @@ impl EtherscanClient {
         &self,
         token_address: Address,
         snapshot_timepoint: u64,
+        rpc_url: &str,
         balance: U256,
     ) -> Result<Vec<TokenHolder>> {
         log::info!(
@@ -712,8 +729,7 @@ impl EtherscanClient {
 
         // Eligibility here rests on the logs alone — no `getPastVotes` pass narrows the
         // set afterwards — so the range must not reach past the census timepoint.
-        let snapshot_block = self
-            .get_block_by_timestamp(snapshot_timepoint)
+        let snapshot_block = Self::get_block_by_timestamp(snapshot_timepoint, rpc_url)
             .await
             .context("Failed to resolve snapshot timepoint to a block")?;
         log::info!(
@@ -1097,20 +1113,47 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn test_get_block_by_timestamp() {
-        let chain_id = CONFIG.chain_id;
-        let api_key = &CONFIG.etherscan_api_key;
-        let client = EtherscanClient::new(api_key.to_string(), chain_id);
+        let rpc_url = &CONFIG.http_rpc_url;
 
         // A timepoint of the size `E3.requestBlock` carries. Read as a block height it
         // is far beyond any chain head, which is the failure this resolver removes.
         let snapshot_timepoint = 1761201108;
 
-        let block = client
-            .get_block_by_timestamp(snapshot_timepoint)
+        let block = EtherscanClient::get_block_by_timestamp(snapshot_timepoint, rpc_url)
             .await
             .unwrap();
 
         assert!(block > 0);
         assert!(block < snapshot_timepoint);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_get_block_by_timestamp_is_the_last_block_at_or_before() {
+        let rpc_url = &CONFIG.http_rpc_url;
+        let snapshot_timepoint = 1761201108;
+
+        let block = EtherscanClient::get_block_by_timestamp(snapshot_timepoint, rpc_url)
+            .await
+            .unwrap();
+
+        // The boundary must be exact: the resolved block is at or before the timepoint,
+        // and the next one is after it. An off-by-one here silently truncates or extends
+        // the census.
+        let url = rpc_url.parse().unwrap();
+        let provider = ProviderBuilder::new().connect_http(url);
+        let at = provider
+            .get_block_by_number(BlockNumberOrTag::Number(block))
+            .await
+            .unwrap()
+            .unwrap();
+        let next = provider
+            .get_block_by_number(BlockNumberOrTag::Number(block + 1))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(at.header.timestamp <= snapshot_timepoint);
+        assert!(next.header.timestamp > snapshot_timepoint);
     }
 }

--- a/examples/CRISP/server/src/server/token_holders/etherscan.rs
+++ b/examples/CRISP/server/src/server/token_holders/etherscan.rs
@@ -22,7 +22,19 @@ sol! {
         function getPastVotes(address account, uint256 timepoint) external view returns (uint256);
         function balanceOf(address account) external view returns (uint256);
         function decimals() external view returns (uint8);
+        function CLOCK_MODE() external view returns (string);
     }
+}
+
+/// Which unit a census token's `getPastVotes` timepoint is denominated in.
+///
+/// Set by the census token itself, per EIP-6372 — not by Interfold. The census token is
+/// requester-supplied, and OpenZeppelin's `ERC20Votes` defaults to block numbers, so this
+/// must be read per token rather than assumed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClockMode {
+    BlockNumber,
+    Timestamp,
 }
 
 // Config
@@ -480,6 +492,25 @@ impl EtherscanClient {
         balances
     }
 
+    /// Read a census token's EIP-6372 clock mode.
+    ///
+    /// Defaults to block numbers when `CLOCK_MODE()` is absent or unparseable: tokens
+    /// predating EIP-6372 checkpoint on `block.number`, and that is also OpenZeppelin's
+    /// default for `ERC20Votes`.
+    async fn get_clock_mode(token_address: Address, rpc_url: &str) -> ClockMode {
+        let Ok(url) = rpc_url.parse() else {
+            return ClockMode::BlockNumber;
+        };
+        let provider = ProviderBuilder::new().connect_http(url);
+        let token = ERC20Votes::new(token_address, provider);
+
+        match token.CLOCK_MODE().call().await {
+            Ok(mode) if mode.contains("mode=timestamp") => ClockMode::Timestamp,
+            Ok(_) => ClockMode::BlockNumber,
+            Err(_) => ClockMode::BlockNumber,
+        }
+    }
+
     /// Verify actual voting power for an address at an EIP-6372 timepoint
     async fn get_past_votes(
         token_address: Address,
@@ -497,8 +528,18 @@ impl EtherscanClient {
             .await
         {
             Ok(votes) => Ok(votes),
-            Err(_) => {
-                // Fallback to balanceOf if getPastVotes fails
+            Err(e) => {
+                // Fallback to balanceOf if getPastVotes fails. This substitutes a *current*
+                // balance for a historical one, so it is logged: a timepoint in the wrong
+                // unit reverts every call and would otherwise rebuild the whole census
+                // from live balances without a single error.
+                log::warn!(
+                    "getPastVotes failed for {} at timepoint {} ({}), falling back to \
+                     current balanceOf",
+                    voter_address,
+                    timepoint,
+                    e
+                );
                 let balance = token
                     .balanceOf(voter_address)
                     .call()
@@ -555,9 +596,11 @@ impl EtherscanClient {
 
     /// Get all token holders with voting power at a census timepoint.
     ///
-    /// `snapshot_timepoint` is an EIP-6372 timestamp, not a block height. Log discovery
-    /// needs the equivalent block, so both units are used: the block bounds the log
-    /// ranges, the timepoint is passed to `getPastVotes`.
+    /// `snapshot_timepoint` is an EIP-6372 timestamp, not a block height — `E3.requestBlock`
+    /// carries `block.timestamp` regardless of which token forms the census. Log discovery
+    /// needs the equivalent block, so both units are derived here: the block always bounds
+    /// the log ranges, while `getPastVotes` receives whichever unit the census token's own
+    /// `CLOCK_MODE()` reports.
     pub async fn get_token_holders_with_voting_power(
         &self,
         token_address: Address,
@@ -613,17 +656,24 @@ impl EtherscanClient {
         let potential_voters = self.get_potential_voters(&transfer_logs, &delegation_logs);
         log::info!("Found {} potential voters", potential_voters.len());
 
-        // Step 5: Verify actual voting power, at the timepoint rather than the block —
-        // the token checkpoints on `mode=timestamp`.
+        // Step 5: Verify actual voting power. The unit of the `getPastVotes` timepoint is
+        // the census token's to decide, so ask it rather than assuming. Passing the wrong
+        // unit reverts the call and silently degrades the census to current balances.
+        let clock_mode = Self::get_clock_mode(token_address, rpc_url).await;
+        let vote_timepoint = match clock_mode {
+            ClockMode::Timestamp => snapshot_timepoint,
+            ClockMode::BlockNumber => snapshot_block,
+        };
         log::info!(
-            "Verifying voting power at timepoint {}...",
-            snapshot_timepoint
+            "Census token clock is {:?}; verifying voting power at timepoint {}...",
+            clock_mode,
+            vote_timepoint
         );
         let token_holders = self
             .verify_voting_power(
                 token_address,
                 &potential_voters,
-                snapshot_timepoint,
+                vote_timepoint,
                 rpc_url,
                 threshold,
             )

--- a/examples/CRISP/server/src/server/token_holders/etherscan.rs
+++ b/examples/CRISP/server/src/server/token_holders/etherscan.rs
@@ -13,7 +13,9 @@ use eyre::{eyre, Context, Result}; // Add this import
 use reqwest;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
-use tokio::time::{sleep, Duration};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Duration, Instant};
 
 // Define the Votes contract interface for getPastVotes
 sol! {
@@ -90,11 +92,26 @@ pub struct PotentialVoter {
     pub has_delegation: bool,
 }
 
+/// Minimum spacing between Etherscan requests.
+///
+/// Etherscan enforces a per-second call ceiling — 3/sec on the free tier — and rejects
+/// the excess outright rather than queueing it, so requests are spaced client-side.
+/// 500ms leaves headroom under that ceiling for retries and for concurrent rounds
+/// sharing the key. Raise the rate with {with_min_request_interval} on a higher plan.
+const MIN_REQUEST_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How many times a rate-limited request is retried before giving up.
+const RATE_LIMIT_RETRIES: u32 = 5;
+
 /// Client for querying token holder data from Etherscan API.
 pub struct EtherscanClient {
     client: reqwest::Client,
     api_key: String,
     chain_id: u64,
+    /// Completion time of the last request, shared so that every call through this
+    /// client observes one spacing schedule.
+    last_request: Arc<Mutex<Option<Instant>>>,
+    min_interval: Duration,
 }
 
 impl EtherscanClient {
@@ -104,7 +121,30 @@ impl EtherscanClient {
             client: reqwest::Client::new(),
             api_key,
             chain_id,
+            last_request: Arc::new(Mutex::new(None)),
+            min_interval: MIN_REQUEST_INTERVAL,
         }
+    }
+
+    /// Override the spacing between requests, for a plan with a different ceiling.
+    pub fn with_min_request_interval(mut self, interval: Duration) -> Self {
+        self.min_interval = interval;
+        self
+    }
+
+    /// Block until enough time has passed since the previous request.
+    ///
+    /// The lock is held across the wait so concurrent callers queue behind one another
+    /// rather than all observing the same stale timestamp and firing together.
+    async fn throttle(&self) {
+        let mut last = self.last_request.lock().await;
+        if let Some(previous) = *last {
+            let elapsed = previous.elapsed();
+            if elapsed < self.min_interval {
+                sleep(self.min_interval - elapsed).await;
+            }
+        }
+        *last = Some(Instant::now());
     }
 
     /// Resolve an EIP-6372 timestamp timepoint to the highest block mined at or before it.
@@ -174,24 +214,16 @@ impl EtherscanClient {
             ETHERSCAN_API_URL, token, self.chain_id, self.api_key
         );
 
-        let response = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .context("Failed to send request to Etherscan")?;
-        let data: EtherscanResponse<Vec<ContractCreation>> = response
-            .json()
-            .await
-            .context("Failed to parse Etherscan response")?;
+        // Shares the throttle and the in-band error handling with the log queries; it
+        // is the first Etherscan call of a census and counts against the same ceiling.
+        let creations: Vec<ContractCreation> = self
+            .fetch_page(&url, "contract creation")
+            .await?
+            .ok_or_else(|| eyre!("No deployment data found"))?;
 
-        if data.status != "1" {
-            return Err(eyre!("Deployment block not found: {}", data.message));
-        }
-
-        let result = data
-            .result
-            .and_then(|r| r.into_iter().next())
+        let result = creations
+            .into_iter()
+            .next()
             .ok_or_else(|| eyre!("No deployment data found"))?;
 
         // Parse block number (could be hex or decimal)
@@ -218,53 +250,89 @@ impl EtherscanClient {
     ///
     /// Returns `Ok(None)` for the "No records found" response, which is a legitimate
     /// empty result rather than an error.
+    ///
+    /// Rate-limit rejections are retried with exponential backoff. Client-side spacing
+    /// alone cannot prevent them: the ceiling is per API key, so concurrent rounds — or
+    /// anything else sharing the key — can exhaust it between two correctly spaced calls.
     async fn fetch_page<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,
         what: &str,
     ) -> Result<Option<T>> {
-        let body = self
-            .client
-            .get(url)
-            .send()
-            .await
-            .with_context(|| format!("Failed to send {} request to Etherscan", what))?
-            .text()
-            .await
-            .with_context(|| format!("Failed to read {} response body", what))?;
+        let mut backoff = self.min_interval;
 
-        let envelope: EtherscanResponse<serde_json::Value> = serde_json::from_str(&body)
-            .with_context(|| {
-                format!(
-                    "Failed to parse {} response envelope; body was: {}",
-                    what,
-                    body.chars().take(500).collect::<String>()
-                )
-            })?;
+        for attempt in 0..=RATE_LIMIT_RETRIES {
+            self.throttle().await;
 
-        if envelope.status != "1" {
-            if envelope.message.eq_ignore_ascii_case("No records found") {
-                return Ok(None);
+            let body = self
+                .client
+                .get(url)
+                .send()
+                .await
+                .with_context(|| format!("Failed to send {} request to Etherscan", what))?
+                .text()
+                .await
+                .with_context(|| format!("Failed to read {} response body", what))?;
+
+            let envelope: EtherscanResponse<serde_json::Value> = serde_json::from_str(&body)
+                .with_context(|| {
+                    format!(
+                        "Failed to parse {} response envelope; body was: {}",
+                        what,
+                        body.chars().take(500).collect::<String>()
+                    )
+                })?;
+
+            if envelope.status != "1" {
+                if envelope.message.eq_ignore_ascii_case("No records found") {
+                    return Ok(None);
+                }
+
+                // The `result` field carries Etherscan's actual explanation; `message` is
+                // usually just "NOTOK".
+                let detail = match &envelope.result {
+                    Some(serde_json::Value::String(s)) if !s.is_empty() => s.clone(),
+                    _ => envelope.message.clone(),
+                };
+
+                if Self::is_rate_limited(&detail) && attempt < RATE_LIMIT_RETRIES {
+                    log::warn!(
+                        "Etherscan rate limit on {} (attempt {}/{}): {}; retrying in {:?}",
+                        what,
+                        attempt + 1,
+                        RATE_LIMIT_RETRIES,
+                        detail,
+                        backoff
+                    );
+                    sleep(backoff).await;
+                    backoff *= 2;
+                    continue;
+                }
+
+                return Err(eyre!("Etherscan {} request failed: {}", what, detail));
             }
 
-            // The `result` field carries Etherscan's actual explanation; `message` is
-            // usually just "NOTOK".
-            let detail = match &envelope.result {
-                Some(serde_json::Value::String(s)) if !s.is_empty() => s.clone(),
-                _ => envelope.message.clone(),
+            let result = match envelope.result {
+                Some(value) => value,
+                None => return Ok(None),
             };
-            return Err(eyre!("Etherscan {} request failed: {}", what, detail));
+
+            let typed = serde_json::from_value(result)
+                .with_context(|| format!("Failed to parse {} result payload", what))?;
+
+            return Ok(Some(typed));
         }
 
-        let result = match envelope.result {
-            Some(value) => value,
-            None => return Ok(None),
-        };
+        unreachable!("the retry loop returns or errors on its final attempt")
+    }
 
-        let typed = serde_json::from_value(result)
-            .with_context(|| format!("Failed to parse {} result payload", what))?;
-
-        Ok(Some(typed))
+    /// Whether an Etherscan error message describes a rate-limit rejection.
+    ///
+    /// Matched on text because the API reports it in-band with the same `status: "0"`
+    /// it uses for every other failure, with no distinguishing code.
+    fn is_rate_limited(detail: &str) -> bool {
+        let detail = detail.to_ascii_lowercase();
+        detail.contains("rate limit") || detail.contains("too many requests")
     }
 
     /// Get transfer logs for a token
@@ -304,9 +372,7 @@ impl EtherscanClient {
             }
 
             page += 1;
-
-            // Rate limiting - wait 100ms between requests
-            sleep(Duration::from_millis(100)).await;
+            // Spacing between requests is handled by `throttle`, so no sleep here.
         }
 
         Ok(all_logs)
@@ -350,9 +416,7 @@ impl EtherscanClient {
             }
 
             page += 1;
-
-            // Rate limiting - wait 100ms between requests
-            sleep(Duration::from_millis(100)).await;
+            // Spacing between requests is handled by `throttle`, so no sleep here.
         }
 
         Ok(all_logs)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for EIP-6372 timestamp-based voting snapshots.
  * Added timestamp-to-block resolution for historical token-holder and transfer data.
  * Supports block-number and timestamp clock modes when retrieving voting power.
  * Added configurable request throttling and automatic retries for rate-limited requests.

* **Bug Fixes**
  * Corrected snapshot handling to align results with timestamp semantics.
  * Falls back to current balances when historical voting data is unavailable.
  * Improved handling of empty results and API error details.

* **Documentation**
  * Clarified that snapshot fields represent timestamp timepoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->