### PR TITLE
fix: wrap dkg on chain txs for failures

### DIFF
--- a/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
+++ b/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
@@ -325,7 +325,17 @@ CommitteeFinalizer actor receives CommitteeRequested event
 ```
 CiphernodeRegistrySolWriter receives CommitteeFinalizeRequested
 │
+├─ Preflight: should_finalize_committee() (eth_call)
+│   └─ Skips the transaction when the committee is not finalizable
+│      (CommitteeAlreadyFinalized / CommitteeNotRequested /
+│       SubmissionWindowNotClosed / ThresholdNotMet)
+│
 └─ Calls contract.finalizeCommittee(e3Id).send()
+    │
+    │  If the transaction is mined with a failed receipt, the writer runs the
+    │  state check again (send_tx_idempotent in crates/evm/src/helpers.rs). A
+    │  revert with CommitteeAlreadyFinalized means another sender finalized
+    │  after the preflight, so the node logs the outcome and reports no error.
     │
     │  ┌─── ON-CHAIN (CiphernodeRegistryOwnable) ──────────────┐
     │  │                                                         │
@@ -463,7 +473,10 @@ The registry must finalize a ready committee.
    lowest non-expelled `party_id` in the address-sorted runtime committee.
 
 5. **Permissionless finalization**: Anyone can call `finalizeCommittee()` after the deadline — no
-   single point of failure.
+   single point of failure. Because the staggered timers can overlap, more than one node can send
+   the transaction. The losing transaction reverts with `CommitteeAlreadyFinalized`; the writer
+   re-reads the state after the failure and treats that revert as a completed operation, not as a
+   node error.
 
 6. **IMT root snapshot**: The Merkle tree root is captured at request time. Nodes that join/leave
    after the request don't affect this E3's committee.

--- a/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
+++ b/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
@@ -333,9 +333,11 @@ CiphernodeRegistrySolWriter receives CommitteeFinalizeRequested
 └─ Calls contract.finalizeCommittee(e3Id).send()
     │
     │  If the transaction is mined with a failed receipt, the writer runs the
-    │  state check again (send_tx_idempotent in crates/evm/src/helpers.rs). A
-    │  revert with CommitteeAlreadyFinalized means another sender finalized
-    │  after the preflight, so the node logs the outcome and reports no error.
+    │  state check again (send_tx_idempotent in crates/evm/src/helpers.rs).
+    │  A revert with CommitteeAlreadyFinalized plus a non-empty
+    │  getActiveCommitteeNodes list shows that another sender finalized after
+    │  the preflight, so the node logs the outcome and reports no error. The
+    │  Failed stage gives the same revert with an empty list and stays an error.
     │
     │  ┌─── ON-CHAIN (CiphernodeRegistryOwnable) ──────────────┐
     │  │                                                         │
@@ -475,8 +477,9 @@ The registry must finalize a ready committee.
 5. **Permissionless finalization**: Anyone can call `finalizeCommittee()` after the deadline — no
    single point of failure. Because the staggered timers can overlap, more than one node can send
    the transaction. The losing transaction reverts with `CommitteeAlreadyFinalized`; the writer
-   re-reads the state after the failure and treats that revert as a completed operation, not as a
-   node error.
+   re-reads the committee after the failure and treats the revert as a completed operation only when
+   the registry reports a finalized committee. A committee that another sender finalized into the
+   `Failed` stage produces the same revert and stays an error.
 
 6. **IMT root snapshot**: The Merkle tree root is captured at request time. Nodes that join/leave
    after the request don't affect this E3's committee.

--- a/agent/flow-trace/04_DKG_AND_COMPUTATION.md
+++ b/agent/flow-trace/04_DKG_AND_COMPUTATION.md
@@ -673,6 +673,9 @@ phase.
   ├─ Calls contract.publishCommittee(
   │    e3_id, pkCommitment, proof, dkgAttestationBundle
   │  ) when the commitment is unset
+  │  └─ If that transaction is mined with a failed receipt, the writer reads the
+  │     commitment again. An equal commitment from another aggregator completes
+  │     the step; a different commitment stays an error
   └─ Calls contract.publishCommitteePublicKey(e3_id, publicKey) after the
      commitment is available, including after restart
         │

--- a/crates/evm/src/ciphernode_registry/actor.rs
+++ b/crates/evm/src/ciphernode_registry/actor.rs
@@ -14,7 +14,10 @@ use crate::actors::evm_parser::EvmParser;
 use crate::contracts::ICiphernodeRegistry;
 use crate::domain::ciphernode_registry_events::extractor;
 use crate::domain::error_decoder::{decode_error_from_str, format_evm_error};
-use crate::helpers::{encode_zk_proof, send_tx_with_retry, transaction_nonce_guard, EthProvider};
+use crate::helpers::{
+    encode_zk_proof, send_tx_idempotent, send_tx_with_retry, transaction_nonce_guard, EthProvider,
+    TxOutcome,
+};
 use crate::messages::{EvmEventProcessor, InterfoldEvmEvent};
 use actix::prelude::*;
 use alloy::{

--- a/crates/evm/src/ciphernode_registry/effects.rs
+++ b/crates/evm/src/ciphernode_registry/effects.rs
@@ -4,16 +4,34 @@
 
 use super::*;
 
+/// Report whether a contract call error is a revert with the named custom error.
+fn reverts_with(error: &anyhow::Error, error_name: &str) -> bool {
+    decode_error_from_str(&format!("{error:?}"))
+        .as_deref()
+        .is_some_and(|message| message.contains(error_name))
+}
+
 pub async fn submit_ticket_to_registry<P: Provider + WalletProvider + Clone + 'static>(
     provider: EthProvider<P>,
     contract_address: Address,
     e3_id: E3id,
     ticket_number: u64,
-) -> Result<TransactionReceipt> {
+) -> Result<TxOutcome> {
     let e3_id_u256: U256 = e3_id.try_into()?;
     let ticket_number_u256 = U256::from(ticket_number);
 
-    send_tx_with_retry("submitTicket", &["CommitteeNotRequested"], || {
+    let settled_provider = provider.clone();
+    let settled = || async move {
+        ticket_submission_settled(
+            settled_provider,
+            contract_address,
+            e3_id_u256,
+            ticket_number_u256,
+        )
+        .await
+    };
+
+    send_tx_idempotent("submitTicket", &["CommitteeNotRequested"], settled, || {
         let provider = provider.clone();
         async move {
             info!("Calling: contract.submitTicket(..)");
@@ -38,20 +56,73 @@ pub async fn submit_ticket_to_registry<P: Provider + WalletProvider + Clone + 's
     .await
 }
 
+/// Report whether this node's ticket is already recorded on chain.
+///
+/// `submitTicket` reverts with `NodeAlreadySubmitted` for a sender that is
+/// already in the submission set, so a retry that duplicates a mined
+/// submission needs no further attempt.
+async fn ticket_submission_settled<P: Provider + WalletProvider + Clone + 'static>(
+    provider: EthProvider<P>,
+    contract_address: Address,
+    e3_id_u256: U256,
+    ticket_number_u256: U256,
+) -> Result<bool> {
+    let from_address = provider.provider().default_signer_address();
+    let contract = ICiphernodeRegistry::new(contract_address, provider.provider());
+    match contract
+        .submitTicket(e3_id_u256, ticket_number_u256)
+        .from(from_address)
+        .call()
+        .await
+    {
+        Ok(_) => Ok(false),
+        Err(err) => Ok(reverts_with(
+            &anyhow::Error::from(err),
+            "NodeAlreadySubmitted",
+        )),
+    }
+}
+
+/// Report whether the committee no longer waits for finalization.
+///
+/// `finalizeCommittee` reverts with `CommitteeAlreadyFinalized` when the
+/// committee stage is not `Requested`. That stage change is what a successful
+/// finalization produces, so another sender did the work.
+async fn committee_finalization_settled<P: Provider + WalletProvider + Clone + 'static>(
+    provider: EthProvider<P>,
+    contract_address: Address,
+    e3_id_u256: U256,
+) -> Result<bool> {
+    let contract = ICiphernodeRegistry::new(contract_address, provider.provider());
+    match contract.finalizeCommittee(e3_id_u256).call().await {
+        Ok(_) => Ok(false),
+        Err(err) => Ok(reverts_with(
+            &anyhow::Error::from(err),
+            "CommitteeAlreadyFinalized",
+        )),
+    }
+}
+
 pub async fn finalize_committee_on_registry<P: Provider + WalletProvider + Clone + 'static>(
     provider: EthProvider<P>,
     contract_address: Address,
     e3_id: E3id,
-) -> Result<TransactionReceipt> {
+) -> Result<TxOutcome> {
     let e3_id_u256: U256 = e3_id.try_into()?;
 
-    send_tx_with_retry(
+    let settled_provider = provider.clone();
+    let settled = || async move {
+        committee_finalization_settled(settled_provider, contract_address, e3_id_u256).await
+    };
+
+    send_tx_idempotent(
         "finalizeCommittee",
         &[
             "SubmissionWindowNotClosed",
             "CommitteeNotRequested",
             "ThresholdNotMet",
         ],
+        settled,
         || {
             let provider = provider.clone();
             async move {
@@ -152,8 +223,8 @@ pub async fn publish_committee_to_registry<P: Provider + WalletProvider + Clone 
     pk_commitment: [u8; 32],
     dkg_aggregator_proof: Option<&Proof>,
     dkg_attestation_bundle: Option<&[u8]>,
-) -> Result<TransactionReceipt> {
-    let e3_id_u256: U256 = e3_id.try_into()?;
+) -> Result<TxOutcome> {
+    let e3_id_u256: U256 = e3_id.clone().try_into()?;
     let pk_commitment_b256 = B256::from(pk_commitment);
 
     // Skip mode creates non-empty mock-only placeholders before this boundary. An absent payload
@@ -168,31 +239,45 @@ pub async fn publish_committee_to_registry<P: Provider + WalletProvider + Clone 
             .ok_or_else(|| anyhow::anyhow!("mandatory DKG attestation bundle missing"))?,
     );
 
+    // The published commitment must equal ours, which `should_publish_committee`
+    // enforces. A different commitment stays an error.
+    let settled_provider = provider.clone();
+    let settled = || async move {
+        should_publish_committee(settled_provider, contract_address, e3_id, pk_commitment)
+            .await
+            .map(|should_publish| !should_publish)
+    };
+
     // RPC may not have synced finalization yet
-    send_tx_with_retry("publishCommittee", &["CommitteeNotFinalized"], || {
-        let provider = provider.clone();
-        let proof = proof.clone();
-        let attestation_bundle = attestation_bundle.clone();
-        async move {
-            info!("Calling: contract.publishCommittee(..)");
-            let _nonce_guard = transaction_nonce_guard(&provider).await;
-            let from_address = provider.provider().default_signer_address();
-            let current_nonce = provider
-                .provider()
-                .get_transaction_count(from_address)
-                .pending()
-                .await?;
-            let contract = ICiphernodeRegistry::new(contract_address, provider.provider());
-            let builder = contract
-                .publishCommittee(e3_id_u256, pk_commitment_b256, proof, attestation_bundle)
-                .nonce(current_nonce);
-            let pending = builder.send().await?;
-            drop(_nonce_guard);
-            let receipt = pending.get_receipt().await?;
-            require_successful_receipt("publish committee", &receipt)?;
-            Ok(receipt)
-        }
-    })
+    send_tx_idempotent(
+        "publishCommittee",
+        &["CommitteeNotFinalized"],
+        settled,
+        || {
+            let provider = provider.clone();
+            let proof = proof.clone();
+            let attestation_bundle = attestation_bundle.clone();
+            async move {
+                info!("Calling: contract.publishCommittee(..)");
+                let _nonce_guard = transaction_nonce_guard(&provider).await;
+                let from_address = provider.provider().default_signer_address();
+                let current_nonce = provider
+                    .provider()
+                    .get_transaction_count(from_address)
+                    .pending()
+                    .await?;
+                let contract = ICiphernodeRegistry::new(contract_address, provider.provider());
+                let builder = contract
+                    .publishCommittee(e3_id_u256, pk_commitment_b256, proof, attestation_bundle)
+                    .nonce(current_nonce);
+                let pending = builder.send().await?;
+                drop(_nonce_guard);
+                let receipt = pending.get_receipt().await?;
+                require_successful_receipt("publish committee", &receipt)?;
+                Ok(receipt)
+            }
+        },
+    )
     .await
 }
 

--- a/crates/evm/src/ciphernode_registry/effects.rs
+++ b/crates/evm/src/ciphernode_registry/effects.rs
@@ -83,24 +83,30 @@ async fn ticket_submission_settled<P: Provider + WalletProvider + Clone + 'stati
     }
 }
 
-/// Report whether the committee no longer waits for finalization.
+/// Report whether another sender finalized the committee.
 ///
-/// `finalizeCommittee` reverts with `CommitteeAlreadyFinalized` when the
-/// committee stage is not `Requested`. That stage change is what a successful
-/// finalization produces, so another sender did the work.
+/// `finalizeCommittee` reverts with `CommitteeAlreadyFinalized` for every
+/// committee stage that is not `Requested`. The `Failed` stage gives the same
+/// revert, so the revert alone does not show that a committee formed. The
+/// check therefore reads the committee: `getActiveCommitteeNodes` returns an
+/// empty list for each stage other than `Finalized`. A failed formation stays
+/// an error.
 async fn committee_finalization_settled<P: Provider + WalletProvider + Clone + 'static>(
     provider: EthProvider<P>,
     contract_address: Address,
     e3_id_u256: U256,
 ) -> Result<bool> {
     let contract = ICiphernodeRegistry::new(contract_address, provider.provider());
-    match contract.finalizeCommittee(e3_id_u256).call().await {
-        Ok(_) => Ok(false),
-        Err(err) => Ok(reverts_with(
-            &anyhow::Error::from(err),
-            "CommitteeAlreadyFinalized",
-        )),
+    let Err(err) = contract.finalizeCommittee(e3_id_u256).call().await else {
+        return Ok(false);
+    };
+
+    if !reverts_with(&anyhow::Error::from(err), "CommitteeAlreadyFinalized") {
+        return Ok(false);
     }
+
+    let committee = contract.getActiveCommitteeNodes(e3_id_u256).call().await?;
+    Ok(!committee.nodes.is_empty())
 }
 
 pub async fn finalize_committee_on_registry<P: Provider + WalletProvider + Clone + 'static>(

--- a/crates/evm/src/ciphernode_registry/handlers.rs
+++ b/crates/evm/src/ciphernode_registry/handlers.rs
@@ -135,6 +135,7 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<TicketGenerated>
                 );
 
                 let e3_id = msg.e3_id.clone();
+                let log_e3_id = msg.e3_id.clone();
                 let contract_address = self.contract_address;
                 let provider = self.provider.clone();
                 let bus = self.bus.clone();
@@ -146,8 +147,11 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<TicketGenerated>
                         submit_ticket_to_registry(provider, contract_address, e3_id, ticket_id)
                             .await;
                     match result {
-                        Ok(receipt) => {
+                        Ok(TxOutcome::Mined(receipt)) => {
                             info!(tx=%receipt.transaction_hash, "Ticket submitted to registry");
+                        }
+                        Ok(TxOutcome::AlreadySettled) => {
+                            info!(e3_id = %log_e3_id, "Ticket already recorded on chain; skipping submission");
                         }
                         Err(err) => {
                             error!("Failed to submit ticket: {}", format_evm_error(&err));
@@ -194,10 +198,14 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<CommitteeFinalizeRe
 
             info!("Finalizing committee for E3 {:?}", e3_id);
 
+            let log_e3_id = e3_id.clone();
             let result = finalize_committee_on_registry(provider, contract_address, e3_id).await;
             match result {
-                Ok(receipt) => {
+                Ok(TxOutcome::Mined(receipt)) => {
                     info!(tx=%receipt.transaction_hash, "Committee finalized on registry");
+                }
+                Ok(TxOutcome::AlreadySettled) => {
+                    info!(e3_id = %log_e3_id, "Committee finalized by another sender; nothing left to do");
                 }
                 Err(err) => {
                     error!("Failed to finalize committee: {}", format_evm_error(&err));
@@ -316,7 +324,7 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<PublicKeyAggregated
 
             let result: Result<()> = async {
                 if should_publish {
-                    let receipt = publish_committee_to_registry(
+                    let outcome = publish_committee_to_registry(
                         provider.clone(),
                         contract_address,
                         e3_id.clone(),
@@ -325,7 +333,14 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<PublicKeyAggregated
                         dkg_attestation_bundle.as_ref().map(|b| b.as_ref()),
                     )
                     .await?;
-                    info!(tx=%receipt.transaction_hash, "Committee proof published to registry");
+                    match outcome.receipt() {
+                        Some(receipt) => {
+                            info!(tx=%receipt.transaction_hash, "Committee proof published to registry")
+                        }
+                        None => {
+                            info!(e3_id = %e3_id, "Committee proof published by another aggregator; publishing the key candidate")
+                        }
+                    }
                 }
 
                 let receipt = publish_committee_public_key_to_registry(

--- a/crates/evm/src/contracts.rs
+++ b/crates/evm/src/contracts.rs
@@ -167,6 +167,10 @@ sol! {
             uint256 partyId
         ) external view returns (address);
 
+        function getActiveCommitteeNodes(
+            uint256 e3Id
+        ) external view returns (address[] memory nodes, uint256[] memory scores);
+
         function dkgFoldAttestationVerifier() external view returns (address);
 
         function accusationVoteValidity() external view returns (uint256);

--- a/crates/evm/src/helpers.rs
+++ b/crates/evm/src/helpers.rs
@@ -351,6 +351,71 @@ where
     .await
 }
 
+/// Result of a transaction that a concurrent sender can make unnecessary.
+#[derive(Debug)]
+pub enum TxOutcome {
+    /// The transaction was mined and its receipt reports success.
+    Mined(Box<TransactionReceipt>),
+    /// The transaction failed, but the wanted on-chain state is already there.
+    AlreadySettled,
+}
+
+impl TxOutcome {
+    /// The receipt of a mined transaction, or `None` when another sender
+    /// produced the wanted state.
+    pub fn receipt(&self) -> Option<&TransactionReceipt> {
+        match self {
+            TxOutcome::Mined(receipt) => Some(receipt),
+            TxOutcome::AlreadySettled => None,
+        }
+    }
+}
+
+/// Send a transaction whose effect another sender can produce first.
+///
+/// Preflights before the transaction cannot close the window between the
+/// preflight and the block that includes the transaction. A transaction that
+/// loses that race is mined with a failed receipt, and the receipt carries no
+/// revert reason, so [`send_tx_with_retry`] classifies it as a hard failure.
+///
+/// `settled` runs after such a failure. It must report whether the wanted
+/// on-chain state is there now. If it is, the failure is benign and the
+/// operation returns [`TxOutcome::AlreadySettled`]. In all other cases the
+/// original transaction error propagates.
+pub async fn send_tx_idempotent<F, Fut, S, SFut>(
+    operation_name: &str,
+    retry_on_errors: &[&str],
+    settled: S,
+    tx_fn: F,
+) -> Result<TxOutcome>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<TransactionReceipt>>,
+    S: FnOnce() -> SFut,
+    SFut: Future<Output = Result<bool>>,
+{
+    let error = match send_tx_with_retry(operation_name, retry_on_errors, tx_fn).await {
+        Ok(receipt) => return Ok(TxOutcome::Mined(Box::new(receipt))),
+        Err(error) => error,
+    };
+
+    match settled().await {
+        Ok(true) => {
+            info!(
+                "{}: another sender produced the wanted state; treating the failure as benign: {}",
+                operation_name,
+                decode_error_from_str(&format!("{error:#}"))
+                    .unwrap_or_else(|| format!("{error:#}"))
+            );
+            Ok(TxOutcome::AlreadySettled)
+        }
+        Ok(false) => Err(error),
+        Err(check_error) => Err(error.context(format!(
+            "the on-chain state check after the failure also failed: {check_error:#}"
+        ))),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -453,5 +518,64 @@ mod tests {
             task.await.expect("nonce-lock task must not panic");
         }
         assert_eq!(maximum.load(Ordering::SeqCst), 1);
+    }
+
+    /// A mined but reverted transaction. Its message carries no revert reason,
+    /// which is what makes the state check after the failure necessary.
+    fn reverted_transaction() -> anyhow::Error {
+        anyhow::anyhow!("finalize committee transaction 0xabcd reverted on chain")
+    }
+
+    #[tokio::test]
+    async fn idempotent_send_accepts_a_state_another_sender_produced() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&attempts);
+
+        let outcome = send_tx_idempotent(
+            "finalizeCommittee",
+            &["SubmissionWindowNotClosed"],
+            || async { Ok(true) },
+            || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                async { Err(reverted_transaction()) }
+            },
+        )
+        .await
+        .expect("a state that another sender produced is not a failure");
+
+        assert!(matches!(outcome, TxOutcome::AlreadySettled));
+        assert!(outcome.receipt().is_none());
+        // The reason is not retryable, so the transaction runs one time.
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn idempotent_send_reports_a_failure_that_left_work_to_do() {
+        let error = send_tx_idempotent(
+            "finalizeCommittee",
+            &["SubmissionWindowNotClosed"],
+            || async { Ok(false) },
+            || async { Err(reverted_transaction()) },
+        )
+        .await
+        .expect_err("an incomplete operation must stay an error");
+
+        assert!(format!("{error:#}").contains("reverted on chain"));
+    }
+
+    #[tokio::test]
+    async fn idempotent_send_keeps_the_transaction_error_when_the_check_fails() {
+        let error = send_tx_idempotent(
+            "finalizeCommittee",
+            &["SubmissionWindowNotClosed"],
+            || async { Err(anyhow::anyhow!("RPC unavailable")) },
+            || async { Err(reverted_transaction()) },
+        )
+        .await
+        .expect_err("an unreadable state must not hide the transaction failure");
+
+        let message = format!("{error:#}");
+        assert!(message.contains("reverted on chain"), "got: {message}");
+        assert!(message.contains("RPC unavailable"), "got: {message}");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for committee finalization, ticket submission, and committee publication during retries or overlapping transactions.
  * Skips actions that are not currently possible or have already been completed.
  * Rechecks on-chain state after failed transactions to recognize successful completion by another submitter.
  * Preserves errors for conflicting commitments and failed finalization.
  * Added coverage for mined, already-completed, and unsuccessful transaction outcomes.

* **New Features**
  * Added access to active committee nodes and their scores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->