### PR TITLE
fix(cargo): align crate repository metadata with workspace URL

### DIFF
--- a/crates/aggregator/Cargo.toml
+++ b/crates/aggregator/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Aggregators"
-repository = "https://github.com/theinterfold/interfold/crates/aggregator"
+repository.workspace = true
 
 [dependencies]
 alloy = { workspace = true }

--- a/crates/bfv-client/Cargo.toml
+++ b/crates/bfv-client/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - BFV client helpers"
-repository = "https://github.com/theinterfold/interfold/crates/bfv-client"
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/ciphernode-builder/Cargo.toml
+++ b/crates/ciphernode-builder/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Ciphernode Builder"
-repository = "https://github.com/theinterfold/interfold/crates/ciphernode-builder"
+repository.workspace = true
 
 [features]
 test-only-skip-proof-aggregation = []

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold CLI"
-repository = "https://github.com/theinterfold/interfold/crates/cli"
+repository.workspace = true
 build = "build.rs"
 
 [features]

--- a/crates/committee-hash/Cargo.toml
+++ b/crates/committee-hash/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Canonical EVM domain hashes for DKG / decryption aggregator proofs"
-repository = "https://github.com/theinterfold/interfold/crates/committee-hash"
+repository.workspace = true
 
 [dependencies]
 alloy = { workspace = true }

--- a/crates/compute-provider/Cargo.toml
+++ b/crates/compute-provider/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Copmute Provider"
-repository = "https://github.com/theinterfold/interfold/crates/compute-provider"
+repository.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive", "std"] }

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Configuration"
-repository = "https://github.com/theinterfold/interfold/crates/config"
+repository.workspace = true
 
 [dependencies]
 alloy-primitives = { workspace = true }

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Cryptography Library"
-repository = "https://github.com/theinterfold/interfold/crates/cryptography"
+repository.workspace = true
 
 [dependencies]
 aes-gcm = { workspace = true }

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Lightweight node monitoring dashboard for Interfold ciphernodes"
+repository.workspace = true
 
 [dependencies]
 actix-web.workspace = true

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Ciphernode Data persistence"
-repository = "https://github.com/theinterfold/interfold/crates/data"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/entrypoint/Cargo.toml
+++ b/crates/entrypoint/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - CLI Entrypoints"
-repository = "https://github.com/theinterfold/interfold/crates/entrypoint"
+repository.workspace = true
 
 [features]
 test-only-skip-proof-aggregation = [

--- a/crates/events/Cargo.toml
+++ b/crates/events/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Event management for E3 Ciphernodes"
-repository = "https://github.com/theinterfold/interfold/crates/events"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/evm-helpers/Cargo.toml
+++ b/crates/evm-helpers/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold EVM Helpers"
-repository = "https://github.com/theinterfold/interfold/crates/evm-helpers"
+repository.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode EVM Connectors"
-repository = "https://github.com/theinterfold/interfold/crates/evm"
+repository.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/fhe-params/Cargo.toml
+++ b/crates/fhe-params/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold FHE Params"
-repository = "https://github.com/theinterfold/interfold/crates/fhe-params"
+repository.workspace = true
 
 [dependencies]
 fhe = { workspace = true }

--- a/crates/fhe/Cargo.toml
+++ b/crates/fhe/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode FHE Actors"
-repository = "https://github.com/theinterfold/interfold/crates/fhe"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/hamt/Cargo.toml
+++ b/crates/hamt/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - A serializable HAMT implementation"
-repository = "https://github.com/theinterfold/interfold/crates/hamt"
+repository.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - A indexer for Interfold"
-repository = "https://github.com/theinterfold/interfold/crates/indexer"
+repository.workspace = true
 
 [dependencies]
 alloy.workspace = true

--- a/crates/init/Cargo.toml
+++ b/crates/init/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Init Function"
-repository = "https://github.com/theinterfold/interfold/crates/init"
+repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/interfoldup/Cargo.toml
+++ b/crates/interfoldup/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Installer for the Interfold CLI tool"
-repository = "https://github.com/theinterfold/interfold"
+repository.workspace = true
 
 [[bin]]
 name = "interfoldup"

--- a/crates/keyshare/Cargo.toml
+++ b/crates/keyshare/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Keyshare Actors"
-repository = "https://github.com/theinterfold/interfold/crates/keyshare"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/logger/Cargo.toml
+++ b/crates/logger/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Logger"
-repository = "https://github.com/theinterfold/interfold/crates/logger"
+repository.workspace = true
 
 [dependencies]
 e3-events = { workspace = true }

--- a/crates/net/Cargo.toml
+++ b/crates/net/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Networking Components"
-repository = "https://github.com/theinterfold/interfold/crates/net"
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/parity-matrix/Cargo.toml
+++ b/crates/parity-matrix/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Parity Matrix for the linear subspace of Z_q^{n+1}"
-repository = "https://github.com/theinterfold/interfold/crates/parity-matrix"
+repository.workspace = true
 
 [dependencies]
 num-bigint = { workspace = true, features = ["serde"] }

--- a/crates/polynomial/Cargo.toml
+++ b/crates/polynomial/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "A polynomial library with big integer coefficients for cryptographic operations"
-repository = "https://github.com/theinterfold/interfold/crates/polynomial"
+repository.workspace = true
 
 [dependencies]
 num-bigint = { workspace = true, features = ["rand", "serde"] }

--- a/crates/program-server/Cargo.toml
+++ b/crates/program-server/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Program Server"
-repository = "https://github.com/theinterfold/interfold/crates/program-server"
+repository.workspace = true
 
 [dependencies]
 actix-web.workspace = true

--- a/crates/request/Cargo.toml
+++ b/crates/request/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode E3Request Handling Components"
-repository = "https://github.com/theinterfold/interfold/crates/request"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/safe/Cargo.toml
+++ b/crates/safe/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold SAFE"
-repository = "https://github.com/theinterfold/interfold/crates/safe"
+repository.workspace = true
 
 [dependencies]
 sha3 = "0.10.8"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold SDK"
-repository = "https://github.com/theinterfold/interfold/crates/sdk"
+repository.workspace = true
 
 [dependencies]
 e3-evm-helpers = { workspace = true, optional = true }

--- a/crates/slashing/Cargo.toml
+++ b/crates/slashing/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 fault attribution, accusation quorum, and commitment consistency"
-repository = "https://github.com/theinterfold/interfold/crates/slashing"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/sortition/Cargo.toml
+++ b/crates/sortition/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Sortition Components"
-repository = "https://github.com/theinterfold/interfold/crates/sortition"
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description.workspace = true
-repository = "https://github.com/theinterfold/interfold/crates/sync"
+repository.workspace = true
 
 [dependencies]
 actix.workspace = true

--- a/crates/test-helpers/Cargo.toml
+++ b/crates/test-helpers/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Test Helpers"
-repository = "https://github.com/theinterfold/interfold/crates/test-helpers"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "E3 - Interfold Ciphernode Tests"
-repository = "https://github.com/theinterfold/interfold/crates/tests"
+repository.workspace = true
 
 [dependencies]
 actix = { workspace = true }

--- a/crates/zk-helpers/Cargo.toml
+++ b/crates/zk-helpers/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "ZK circuit helpers"
-repository = "https://github.com/theinterfold/interfold/crates/zk-helpers"
+repository.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## What

Thirty-three crate manifests set `repository` to `https://github.com/theinterfold/interfold/crates/<name>`,
which omits `/tree/main` and returns 404. This points every workspace member at the inherited
`[workspace.package]` value instead, which already holds the correct URL and which twelve crates
already use.

Also folded in two adjacent gaps found during review: `e3-dashboard` had no `repository` field at all,
and `interfoldup` duplicated the root URL literally rather than inheriting it. `examples/CRISP` keeps
its own literal, since it is in the root workspace's `exclude` list and is its own `[workspace]` root,
so it cannot inherit.

The crates are not on crates.io yet, but `.github/workflows/releases.yml` publishes with
`publish = true`, so the broken URL would ship on the first release.

Closes part of #1794 (section 1).

## Checklist

- [x] **Verified at the smallest covering scope** — this is manifest metadata with no code path, so
      verification is at the manifest layer:
      `cargo metadata --no-deps --format-version 1` (all 45 packages now report
      `https://github.com/theinterfold/interfold`, zero missing — was 44 correct + 1 missing before),
      `cargo verify-project` (`{"success":"true"}`), `pnpm check:license`, `pnpm check:docs`.
      Confirmed no code reads `CARGO_PKG_REPOSITORY` and no workflow or script reads the manifest
      `repository` field.
- [x] **Harness docs** — not applicable. No contract, circuit, actor routing, CLI behavior, or formula
      changes; `repository` is inert Cargo metadata.
- [x] **Invariants** — checked against `agent/INVARIANTS.md`. Nothing in the meta-invariant list
      (committee ordering, thresholds, proof multiplicity, hashing, signatures, witness shape, event
      identity, replay) is touched.
- [x] **Known bugs table** — not applicable. No protocol concern fixed or introduced.
- [x] **Breaking?** — no. Metadata only; no API, ABI, or behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized repository metadata across packages by inheriting the shared workspace repository configuration.
  * Removed package-specific repository URLs, improving consistency and simplifying future metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->