### PR TITLE
fix(crisp): remove unused census constant

### DIFF
--- a/examples/CRISP/packages/crisp-contracts/tests/onchain-census.test.ts
+++ b/examples/CRISP/packages/crisp-contracts/tests/onchain-census.test.ts
@@ -10,7 +10,6 @@ import { expect } from 'chai'
 import { deployCRISPProgram, deployHonkVerifier, deployMockInterfold, deployOnchainHonkVerifier, ethers } from './utils'
 import type { CRISPProgram, HonkVerifier, MockInterfold } from '../types'
 
-const CONSTANT = 0
 const CUSTOM = 1
 const ONCHAIN = 2
 


### PR DESCRIPTION
Removes the unused census-mode constant from the on-chain census test so the repository lint hook passes.

Checks:
- `pnpm --dir examples/CRISP lint`
- `pnpm lint`
- pre-push checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused test declaration; no user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->