### PR TITLE
feat: handle disabled proof slash policies [skip-line-limit]

### DIFF
--- a/agent/CRATES_ARCHITECTURE.md
+++ b/agent/CRATES_ARCHITECTURE.md
@@ -541,14 +541,15 @@ flowchart TD
     Quorum -->|yes| Decision[AccusationQuorumReached]
     Wait --> Timeout[E3 timeout / formation failure]
     Decision --> Writer[SlashingManagerSolWriter]
-    Writer --> Eligible{right chain, slashable outcome, and ranked submitter?}
-    Eligible -->|no| Ignore[ignore locally]
-    Eligible -->|yes| Effects{EffectsEnabled?}
+    Writer --> Effects{EffectsEnabled?}
     Effects -->|no| Deferred[in-memory deferred intents]
-    Deferred -->|startup reconciliation complete| Submit
+    Deferred -->|startup reconciliation complete| Policy
     Effects -->|yes| Gate{semantic intent already deferred, in flight, or complete?}
     Gate -->|yes| Ignore[coalesce duplicate]
-    Gate -->|no| Submit[submit now or after rank delay]
+    Gate -->|no| Policy{proof slash policy enabled?}
+    Policy -->|no| Exclude[durable E3-scoped local exclusion]
+    Policy -->|yes, ranked voter| Submit[submit now or after rank delay]
+    Policy -->|yes, not ranked| Ignore
     Submit --> Outcome{transaction outcome}
     Outcome -->|success or classified benign result| Complete[retain completed key]
     Outcome -->|retryable failure| Retry[clear in-flight key]
@@ -571,11 +572,16 @@ attributable to a canonical party before they become slashing evidence. Replayed
 semantic replay domain across deferred, in-flight, and completed submissions. Retryable submission
 failures release their key. Successful or known-benign terminal results retain it.
 
+Every node reads the proof-type policy after a fault quorum. A disabled policy produces a durable,
+E3-scoped `CommitteeMemberExcluded` fact instead of a transaction that must revert. This fact is
+not an on-chain expulsion: it changes only the current E3's collectors and aggregator selection.
+The canonical N-member roster remains unchanged for proof binding, rewards, and registry state.
+
 The gate is deliberately described as in-memory: there is no durable external-effect outbox or
 persisted transaction intent. A crash after snapshot advancement but before receipt classification
 can therefore lose the local redrive state, and a crash after submission can require on-chain
 reconciliation to distinguish landed from missing work. Closing that gap requires a durable
-intent/result state machine and contract preflight, not another process-local set.
+intent/result state machine and receipt reconciliation, not another process-local set.
 
 ## Program-server trust boundary
 

--- a/agent/flow-trace/04_DKG_AND_COMPUTATION.md
+++ b/agent/flow-trace/04_DKG_AND_COMPUTATION.md
@@ -7,7 +7,8 @@ using threshold BFV (TrBFV) cryptography. This produces a collective public key 
 party knowing the full secret key. Later, the committee produces decryption shares; all committee
 members buffer them, and the active aggregator combines them. The runtime first normalizes the
 finalized committee into ascending ticket-score order, and the active aggregator is then the lowest
-non-expelled `party_id` in that normalized order.
+`party_id` that has not been excluded from the current E3. An exclusion can come from an on-chain
+expulsion or from a proof-fault quorum while the matching slash policy is disabled.
 
 Delegated bonding does not alter cryptographic identity. Every ECDSA proof signature is still made
 by the hot operator key and verified against the operator address snapshotted into the committee.
@@ -589,16 +590,17 @@ phase.
 │
 ├─ KeyshareCreatedFilterBuffer gates events:
   │   └─ Only accepts KeyshareCreated from verified committee members
-  │   └─ Compares committee, keyshare, and expulsion identities as parsed EVM addresses;
-  │      EIP-55 casing differences cannot bypass an expulsion or its buffered-share purge
+  │   └─ Compares committee, keyshare, and exclusion identities as parsed EVM addresses;
+  │      EIP-55 casing differences cannot bypass an exclusion or its buffered-share purge
   │   └─ Buffers until BOTH CommitteeFinalized and AggregatorChanged(is_aggregator=true)
-  │   └─ On expulsion-driven handoff, the next active aggregator flushes its existing buffer
+  │   └─ On exclusion-driven handoff, the next active aggregator flushes its existing buffer
 │
   ├─ Only the active aggregator's buffer flushes into PublicKeyAggregator
   │
-  ├─ When N distinct keyshares collected (committee size from on-chain `threshold_n`):
+  ├─ When every non-excluded member has submitted a keyshare:
+│   │   → The live count can fall below N after a confirmed fault, but it must still be at least H
 │   │
-│   ├─ C1 verification runs over all N submitters; parties failing C1 are marked dishonest
+│   ├─ C1 verification runs over all collected non-excluded submitters; failures are dishonest
 │   │
 │   ├─ Honest-set selection (compile-time H from `committee::active`, may be < N):
 │   │     • Require at least H parties with valid C1 proofs; otherwise E3Failed
@@ -618,7 +620,9 @@ phase.
 │   ├─ 2. Build C5 proof request (H canonical honest keyshares):
 │   │     proof_request.keyshare_bytes = [pk_share for each H party]
 │   │     proof_request.aggregated_pk_bytes = aggregate_pk
-│   │     proof_request.committee_n = committee_h = H  // C5 circuit sized for H, not N
+│   │     proof_request.committee_n = N
+│   │     proof_request.committee_h = H
+│   │     proof_request.committee_threshold = T
 │   │     (per-share compute_pk_commitment already checked against C1; aggregate
 │   │      commitment is proved as a C5 public output, not pre-published here)
 │   │
@@ -646,7 +650,8 @@ phase.
 │   │     │     node_fold_proofs, c5_proof, party_ids, params_preset
 │   │     │   })
 │   │     │   → exactly H NodeFold proofs and H unique party ids
-│   │     │   → exactly N ordered committee addresses (`topNodes`), where canonical H < N
+│   │     │   → exactly N ordered committee addresses from `CommitteeFinalized` (`topNodes`),
+│   │     │     including a member excluded before it submitted a keyshare
 │   │     │   → Rust validates both dimensions before invoking the compiled circuit
 │   │     ├─ Tracks the in-flight correlation id
 │   │     ├─ ComputeRequestError now emits
@@ -931,14 +936,14 @@ InterfoldSolReader decodes CiphertextOutputPublished event
   All committee members receive DecryptionshareCreated events
 │
   ├─ DecryptionshareCreatedBuffer gates events:
-  │   ├─ Tracks expelled parties
+  │   ├─ Tracks parties excluded by on-chain expulsion or the disabled-policy fallback
   │   ├─ Buffers until AggregatorChanged(is_aggregator=true)
   │   └─ Flushes verified shares to ThresholdPlaintextAggregator when this node is active
   │
   ├─ ThresholdPlaintextAggregator receives flushed shares
   │   ├─ Verifies sender is in committee
   │   ├─ Adds the share if verified
-  │   └─ Ignores non-members or expelled parties
+  │   └─ Ignores non-members or excluded parties
 │
   ├─ C6 VERIFICATION (per-share, on active aggregator):
 │   ShareVerificationActor receives C6 signed proofs

--- a/agent/flow-trace/05_FAILURE_REFUND_SLASHING.md
+++ b/agent/flow-trace/05_FAILURE_REFUND_SLASHING.md
@@ -517,7 +517,23 @@ AccusationQuorumReached event arrives at SlashingManagerSolWriter
 │     Coalesce by the contract replay tuple (chainId, e3Id, accused, proofType)
 │     After EffectsEnabled, release each retained intent once and track it in flight
 │
-├─ 2. STAGGERED SUBMISSION (fallback submitters):
+├─ 2. READ THE PROOF-TYPE POLICY ON EVERY COMMITTEE NODE:
+│     reason = keccak256(abi.encodePacked(uint256(proofType)))
+│     policy = SlashingManager.getSlashPolicy(reason)
+│     │
+│     ├─ Policy disabled:
+│     │   ├─ Do not submit a transaction that can only revert
+│     │   ├─ Publish durable CommitteeMemberExcluded { party_id: None }
+│     │   └─ Stop waiting for the confirmed faulty member in this E3 only
+│     │       → No on-chain slash, ban, reward hold, or future-selection change is implied
+│     │
+│     ├─ Policy enabled but not configured for proof attestations:
+│     │   └─ Report the configuration error; do not invent an exclusion
+│     │
+│     └─ Policy read fails:
+│         └─ Do not invent an exclusion; ranked voters retain the transaction path
+│
+├─ 3. STAGGERED SUBMISSION (enabled policy, fallback submitters):
 │     Rank all agreeing voters by address (sorted ascending)
 │     My rank = position in sorted list
 │     │
@@ -528,7 +544,7 @@ AccusationQuorumReached event arrives at SlashingManagerSolWriter
 │     → Prevents multiple nodes wasting gas on same slash
 │     → Higher-rank submitters expect DuplicateEvidence revert
 │
-├─ 3. Encode attestation evidence:
+├─ 4. Encode attestation evidence:
 │     proof = abi.encode(
 │       proofType,       // uint256 — which proof failed (C0-C7)
 │       voters[],        // address[] — sorted ascending
@@ -539,11 +555,11 @@ AccusationQuorumReached event arrives at SlashingManagerSolWriter
 │       signatures[]     // bytes[] — per-voter ECDSA signatures
 │     )
 │
-├─ 4. Prefer proposeSlashByDkgParty(e3Id, partyId, proof) when the
+├─ 5. Prefer proposeSlashByDkgParty(e3Id, partyId, proof) when the
 │     canonical DKG slot resolves; otherwise call proposeSlash(e3Id, accused, proof)
 │     → On-chain verification happens (see Lane A below)
 │
-└─ 5. Handle result:
+└─ 6. Handle result:
      ├─ Success: log transaction hash
      ├─ DuplicateEvidence / stale committee attribution: terminal and logged as warning
      └─ Other RPC or contract failures: reported and made eligible for a later retry event
@@ -1280,6 +1296,18 @@ When CommitteeMemberExpelled event arrives from EVM:
         ├─ CiphernodeSelector: cleans e3_cache entry for this e3_id
         └─ E3Router: removes E3Context for this e3_id
 ```
+
+When a proof-fault quorum is reached while its on-chain policy is disabled, the writer publishes a
+separate `CommitteeMemberExcluded` event. Sortition resolves its stable `party_id` from the same
+immutable `CommitteeFinalized` roster and republishes the enriched event. The keyshare collectors,
+public-key aggregator, plaintext aggregator, and active-aggregator selector then treat that party as
+unavailable for this E3. The final DKG proof still receives all N canonical committee addresses
+from `CommitteeFinalized`; it never derives the proof-bound roster from the reduced keyshare set.
+
+This fallback is availability-only. The excluded operator remains an active on-chain committee
+member, can remain eligible for future E3s, and can receive any reward that the contracts still
+assign to it. Enable the matching slash policy when the deployment requires economic punishment,
+an on-chain reward hold, or registry expulsion.
 
 ---
 

--- a/crates/aggregator/src/ext.rs
+++ b/crates/aggregator/src/ext.rs
@@ -74,7 +74,7 @@ impl E3Extension for PublicKeyAggregatorExtension {
             return;
         }
 
-        let Some(fhe) = ctx.get_dependency(FHE_KEY) else {
+        let Some(fhe) = ctx.get_dependency(FHE_KEY).cloned() else {
             self.bus.err(
                 EType::PublickeyAggregation,
                 anyhow!(ERROR_PUBKEY_FHE_MISSING),
@@ -87,11 +87,30 @@ impl E3Extension for PublicKeyAggregatorExtension {
             threshold_m,
             seed,
             params_preset,
+            committee,
             ..
         } = data.clone();
         let dkg_fold_attestation_context = ctx
             .get_dependency(DKG_FOLD_ATTESTATION_CONTEXT_KEY)
             .copied();
+        let committee_addresses = match committee_addresses_from_node_strings(&committee) {
+            Ok(addresses) if addresses.len() == threshold_n => addresses,
+            Ok(addresses) => {
+                self.bus.err(
+                    EType::PublickeyAggregation,
+                    anyhow!(
+                        "Could not create PublicKeyAggregator for E3 {e3_id}: selected event has {} committee addresses; expected {threshold_n}.",
+                        addresses.len()
+                    ),
+                );
+                return;
+            }
+            Err(error) => {
+                self.bus.err(EType::PublickeyAggregation, error);
+                return;
+            }
+        };
+        ctx.set_dependency(COMMITTEE_ADDRESSES_KEY, committee_addresses.clone());
         let repo = ctx.repositories().publickey(&e3_id);
         let sync_state = repo.send(Some(PublicKeyAggregatorState::init(
             threshold_n,
@@ -113,13 +132,14 @@ impl E3Extension for PublicKeyAggregatorExtension {
             }
         };
         let value = create_publickey_aggregator(
-            fhe.clone(),
+            fhe,
             self.bus.clone(),
             e3_id,
             sync_state,
             params_preset,
             committee_size,
             dkg_fold_attestation_context,
+            committee_addresses,
         );
 
         ctx.set_event_recipient("publickey", Some(value));
@@ -175,6 +195,7 @@ impl E3Extension for PublicKeyAggregatorExtension {
             committee_size,
             ctx.get_dependency(DKG_FOLD_ATTESTATION_CONTEXT_KEY)
                 .copied(),
+            load_committee_addresses(ctx)?,
         );
 
         // send to context
@@ -192,7 +213,13 @@ fn create_publickey_aggregator(
     params_preset: BfvPreset,
     committee_size: CiphernodesCommitteeSize,
     dkg_fold_attestation_context: Option<DkgFoldAttestationContext>,
+    committee_addresses: Vec<Address>,
 ) -> Recipient<InterfoldEvent> {
+    let canonical_party_nodes = committee_addresses
+        .into_iter()
+        .enumerate()
+        .map(|(party_id, node)| (party_id as u64, node.to_string()))
+        .collect();
     KeyshareCreatedFilterBuffer::new(
         PublicKeyAggregator::new(
             PublicKeyAggregatorParams {
@@ -202,6 +229,7 @@ fn create_publickey_aggregator(
                 params_preset,
                 committee_size,
                 dkg_fold_attestation_context,
+                canonical_party_nodes,
             },
             sync_state,
         )

--- a/crates/aggregator/src/ext.rs
+++ b/crates/aggregator/src/ext.rs
@@ -111,11 +111,13 @@ impl E3Extension for PublicKeyAggregatorExtension {
             }
         };
         ctx.set_dependency(COMMITTEE_ADDRESSES_KEY, committee_addresses.clone());
+        let canonical_party_nodes = party_nodes_from_committee_addresses(&committee_addresses);
         let repo = ctx.repositories().publickey(&e3_id);
         let sync_state = repo.send(Some(PublicKeyAggregatorState::init(
             threshold_n,
             threshold_m,
             seed,
+            canonical_party_nodes,
         )));
 
         let committee_size = match CiphernodesCommitteeSize::from_threshold(
@@ -139,7 +141,6 @@ impl E3Extension for PublicKeyAggregatorExtension {
             params_preset,
             committee_size,
             dkg_fold_attestation_context,
-            committee_addresses,
         );
 
         ctx.set_event_recipient("publickey", Some(value));
@@ -158,6 +159,8 @@ impl E3Extension for PublicKeyAggregatorExtension {
         if !sync_state.has() {
             return Ok(());
         };
+        let recovered_state = sync_state.try_get()?;
+        remember_committee_dependencies_from_publickey_state(ctx, &recovered_state)?;
 
         // Get deps
         let Some(fhe) = ctx.get_dependency(FHE_KEY) else {
@@ -195,7 +198,6 @@ impl E3Extension for PublicKeyAggregatorExtension {
             committee_size,
             ctx.get_dependency(DKG_FOLD_ATTESTATION_CONTEXT_KEY)
                 .copied(),
-            load_committee_addresses(ctx)?,
         );
 
         // send to context
@@ -213,13 +215,7 @@ fn create_publickey_aggregator(
     params_preset: BfvPreset,
     committee_size: CiphernodesCommitteeSize,
     dkg_fold_attestation_context: Option<DkgFoldAttestationContext>,
-    committee_addresses: Vec<Address>,
 ) -> Recipient<InterfoldEvent> {
-    let canonical_party_nodes = committee_addresses
-        .into_iter()
-        .enumerate()
-        .map(|(party_id, node)| (party_id as u64, node.to_string()))
-        .collect();
     KeyshareCreatedFilterBuffer::new(
         PublicKeyAggregator::new(
             PublicKeyAggregatorParams {
@@ -229,7 +225,6 @@ fn create_publickey_aggregator(
                 params_preset,
                 committee_size,
                 dkg_fold_attestation_context,
-                canonical_party_nodes,
             },
             sync_state,
         )
@@ -377,6 +372,14 @@ fn addresses_for_sorted_party_ids(party_nodes: &HashMap<u64, String>) -> Result<
     committee_addresses_in_party_order(&party_ids, party_nodes)
 }
 
+fn party_nodes_from_committee_addresses(committee_addresses: &[Address]) -> HashMap<u64, String> {
+    committee_addresses
+        .iter()
+        .enumerate()
+        .map(|(party_id, node)| (party_id as u64, node.to_string()))
+        .collect()
+}
+
 fn publickey_state_committee_addresses(
     state: &PublicKeyAggregatorState,
 ) -> Result<Option<Vec<Address>>> {
@@ -389,6 +392,16 @@ fn publickey_state_committee_addresses(
             if !party_nodes.is_empty() =>
         {
             Ok(Some(addresses_for_sorted_party_ids(party_nodes)?))
+        }
+        PublicKeyAggregatorState::Collecting {
+            canonical_party_nodes,
+            ..
+        }
+        | PublicKeyAggregatorState::VerifyingC1 {
+            canonical_party_nodes,
+            ..
+        } if !canonical_party_nodes.is_empty() => {
+            Ok(Some(addresses_for_sorted_party_ids(canonical_party_nodes)?))
         }
         _ => Ok(None),
     }
@@ -694,7 +707,10 @@ impl E3Extension for ThresholdPlaintextAggregatorExtension {
 mod tests {
     use super::*;
     use alloy::primitives::address;
-    use e3_events::OrderedSet;
+    use e3_data::{DataStore, InMemStore};
+    use e3_events::{OrderedSet, Seed};
+    use e3_request::{ContextRepositoryFactory, E3ContextParams, E3Meta};
+    use e3_test_helpers::get_common_setup;
     use e3_utils::ArcBytes;
     use std::collections::{BTreeSet, HashMap};
 
@@ -749,6 +765,89 @@ mod tests {
                 address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
             ]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn recovers_full_committee_addresses_from_collecting_state() -> Result<()> {
+        let committee_addresses = vec![
+            address!("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"),
+            address!("0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"),
+            address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
+        ];
+        let state = PublicKeyAggregatorState::init(
+            3,
+            1,
+            Seed([0; 32]),
+            party_nodes_from_committee_addresses(&committee_addresses),
+        );
+
+        let recovered = publickey_state_committee_addresses(&state)?.expect("addresses");
+
+        assert_eq!(recovered, committee_addresses);
+        Ok(())
+    }
+
+    #[actix::test]
+    async fn publickey_hydration_restores_committee_dependencies_first() -> Result<()> {
+        let (bus, rng, seed, params, crp, _errors, _history) =
+            get_common_setup(Some(BfvPreset::InsecureThreshold512.into()))?;
+        let e3_id = E3id::new("42", 1);
+        let store = DataStore::from_in_mem(&InMemStore::new(false).start());
+        let mut ctx = E3Context::from_params(E3ContextParams {
+            repository: store.repositories().context(&e3_id),
+            e3_id: e3_id.clone(),
+            extensions: Arc::new(Vec::new()),
+        });
+        ctx.set_dependency(FHE_KEY, Arc::new(Fhe::new(params, crp, rng)));
+        ctx.set_dependency(
+            META_KEY,
+            E3Meta {
+                threshold_m: 1,
+                threshold_n: 3,
+                seed,
+                params_preset: BfvPreset::InsecureThreshold512,
+                params: ArcBytes::from_bytes(&[]),
+                error_size: ArcBytes::from_bytes(&[]),
+            },
+        );
+
+        let committee_addresses = vec![
+            address!("0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"),
+            address!("0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"),
+            address!("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
+        ];
+        let honest_committee_addresses = committee_addresses[..2].to_vec();
+        let state = PublicKeyAggregatorState::Complete {
+            public_key: ArcBytes::from_bytes(&[1, 2, 3]),
+            keyshares: OrderedSet::new(),
+            nodes: OrderedSet::new(),
+            committee_addresses: committee_addresses.clone(),
+            honest_committee_addresses: honest_committee_addresses.clone(),
+        };
+        ctx.repositories()
+            .publickey(&e3_id)
+            .write_sync(&state)
+            .await?;
+        let snapshot = E3ContextSnapshot {
+            e3_id,
+            recipients: vec!["publickey".to_string()],
+            dependencies: Vec::new(),
+        };
+
+        PublicKeyAggregatorExtension::create(&bus)
+            .hydrate(&mut ctx, &snapshot)
+            .await?;
+
+        assert_eq!(
+            ctx.get_dependency(COMMITTEE_ADDRESSES_KEY),
+            Some(&committee_addresses)
+        );
+        assert_eq!(
+            ctx.get_dependency(HONEST_COMMITTEE_ADDRESSES_KEY),
+            Some(&honest_committee_addresses)
+        );
+        assert!(ctx.get_event_recipient("publickey").is_some());
         Ok(())
     }
 

--- a/crates/aggregator/src/plaintext_aggregation/actor.rs
+++ b/crates/aggregator/src/plaintext_aggregation/actor.rs
@@ -18,12 +18,13 @@ use anyhow::{anyhow, bail, ensure, Result};
 use e3_data::Persistable;
 use e3_events::{
     prelude::*, trap, AggregationProofPending, AggregationProofSigned, BusHandle,
-    CommitteeMemberExpelled, ComputeRequest, ComputeRequestError, ComputeRequestErrorKind,
-    ComputeResponse, ComputeResponseKind, CorrelationId, DecryptedSharesAggregationProofRequest,
-    DecryptionAggregationRequest, DecryptionshareCreated, Die, E3Failed, E3Stage, E3id, EType,
-    EventContext, FailureReason, InterfoldEvent, InterfoldEventData, PlaintextAggregated, Proof,
-    Sequenced, ShareVerificationComplete, ShareVerificationDispatched, SignedProofPayload,
-    TypedEvent, VerificationKind, ZkRequest, ZkResponse,
+    CommitteeMemberExcluded, CommitteeMemberExpelled, ComputeRequest, ComputeRequestError,
+    ComputeRequestErrorKind, ComputeResponse, ComputeResponseKind, CorrelationId,
+    DecryptedSharesAggregationProofRequest, DecryptionAggregationRequest, DecryptionshareCreated,
+    Die, E3Failed, E3Stage, E3id, EType, EventContext, FailureReason, InterfoldEvent,
+    InterfoldEventData, PlaintextAggregated, Proof, Sequenced, ShareVerificationComplete,
+    ShareVerificationDispatched, SignedProofPayload, TypedEvent, VerificationKind, ZkRequest,
+    ZkResponse,
 };
 use e3_fhe_params::BfvPreset;
 use e3_sortition::{E3CommitteeContainsRequest, E3CommitteeContainsResponse, Sortition};

--- a/crates/aggregator/src/plaintext_aggregation/decryption_share_buffer.rs
+++ b/crates/aggregator/src/plaintext_aggregation/decryption_share_buffer.rs
@@ -35,6 +35,10 @@ impl DecryptionshareCreatedBuffer {
         }
     }
 
+    fn forward(dest: &Addr<ThresholdPlaintextAggregator>, event: InterfoldEvent) {
+        dest.do_send(event);
+    }
+
     fn flush(&mut self) {
         if !self.is_aggregator {
             return;
@@ -45,13 +49,16 @@ impl DecryptionshareCreatedBuffer {
                 InterfoldEventData::DecryptionshareCreated(data)
                     if !self.expelled_parties.contains(&data.party_id) =>
                 {
-                    self.dest.do_send(event);
+                    Self::forward(&self.dest, event);
                 }
                 InterfoldEventData::CommitteeMemberExpelled(data) if data.party_id.is_some() => {
-                    self.dest.do_send(event);
+                    Self::forward(&self.dest, event);
+                }
+                InterfoldEventData::CommitteeMemberExcluded(data) if data.party_id.is_some() => {
+                    Self::forward(&self.dest, event);
                 }
                 InterfoldEventData::E3RequestComplete(_) | InterfoldEventData::Shutdown(_) => {
-                    self.dest.do_send(event);
+                    Self::forward(&self.dest, event);
                 }
                 _ => {}
             }
@@ -78,7 +85,7 @@ impl Handler<InterfoldEvent> for DecryptionshareCreatedBuffer {
                 }
 
                 if self.is_aggregator {
-                    self.dest.do_send(msg);
+                    Self::forward(&self.dest, msg);
                 } else {
                     self.buffer.push(msg);
                 }
@@ -88,7 +95,9 @@ impl Handler<InterfoldEvent> for DecryptionshareCreatedBuffer {
                     return;
                 };
 
-                self.expelled_parties.insert(party_id);
+                if !self.expelled_parties.insert(party_id) {
+                    return;
+                }
                 self.buffer.retain(|event| {
                     !matches!(
                         event.get_data(),
@@ -98,7 +107,29 @@ impl Handler<InterfoldEvent> for DecryptionshareCreatedBuffer {
                 });
 
                 if self.is_aggregator {
-                    self.dest.do_send(msg);
+                    Self::forward(&self.dest, msg);
+                } else {
+                    self.buffer.push(msg);
+                }
+            }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                let Some(party_id) = data.party_id else {
+                    return;
+                };
+
+                if !self.expelled_parties.insert(party_id) {
+                    return;
+                }
+                self.buffer.retain(|event| {
+                    !matches!(
+                        event.get_data(),
+                        InterfoldEventData::DecryptionshareCreated(share)
+                            if share.party_id == party_id
+                    )
+                });
+
+                if self.is_aggregator {
+                    Self::forward(&self.dest, msg);
                 } else {
                     self.buffer.push(msg);
                 }
@@ -108,11 +139,11 @@ impl Handler<InterfoldEvent> for DecryptionshareCreatedBuffer {
                 self.flush();
             }
             InterfoldEventData::E3RequestComplete(_) | InterfoldEventData::Shutdown(_) => {
-                self.dest.do_send(msg);
+                Self::forward(&self.dest, msg);
             }
             _ => {
                 if self.is_aggregator {
-                    self.dest.do_send(msg);
+                    Self::forward(&self.dest, msg);
                 }
             }
         }

--- a/crates/aggregator/src/plaintext_aggregation/handlers.rs
+++ b/crates/aggregator/src/plaintext_aggregation/handlers.rs
@@ -91,6 +91,9 @@ impl Handler<InterfoldEvent> for ThresholdPlaintextAggregator {
             InterfoldEventData::CommitteeMemberExpelled(data) => {
                 self.notify_sync(ctx, TypedEvent::new(data, ec))
             }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                self.notify_sync(ctx, TypedEvent::new(data, ec))
+            }
             InterfoldEventData::ShareVerificationComplete(data) => {
                 self.notify_sync(ctx, TypedEvent::new(data, ec))
             }
@@ -247,6 +250,35 @@ impl Handler<TypedEvent<CommitteeMemberExpelled>> for ThresholdPlaintextAggregat
                     self.dispatch_c6_verification(state.c6_proofs.clone(), ec)?;
                 }
 
+                Ok(())
+            },
+        )
+    }
+}
+
+impl Handler<TypedEvent<CommitteeMemberExcluded>> for ThresholdPlaintextAggregator {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        msg: TypedEvent<CommitteeMemberExcluded>,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        trap(
+            EType::PlaintextAggregation,
+            &self.bus.with_ec(msg.get_ctx()),
+            || {
+                let (msg, ec) = msg.into_components();
+                let Some(party_id) = msg.party_id else {
+                    return Ok(());
+                };
+
+                self.handle_member_expelled(party_id, &ec)?;
+                if let Some(ThresholdPlaintextAggregatorState::VerifyingC6(ref state)) =
+                    self.state.get()
+                {
+                    self.dispatch_c6_verification(state.c6_proofs.clone(), ec)?;
+                }
                 Ok(())
             },
         )

--- a/crates/aggregator/src/public_key_aggregation/actor.rs
+++ b/crates/aggregator/src/public_key_aggregation/actor.rs
@@ -46,6 +46,8 @@ pub struct PublicKeyAggregator {
     params_preset: BfvPreset,
     committee_size: CiphernodesCommitteeSize,
     dkg_fold_attestation_context: Option<DkgFoldAttestationContext>,
+    /// Immutable finalized committee keyed by stable sortition party ID.
+    canonical_party_nodes: HashMap<u64, String>,
     /// DKG recursive aggregation events received before entering GeneratingC5Proof.
     early_dkg_proofs: Vec<TypedEvent<DKGRecursiveAggregationComplete>>,
 }
@@ -57,6 +59,7 @@ pub struct PublicKeyAggregatorParams {
     pub params_preset: BfvPreset,
     pub committee_size: CiphernodesCommitteeSize,
     pub dkg_fold_attestation_context: Option<DkgFoldAttestationContext>,
+    pub canonical_party_nodes: HashMap<u64, String>,
 }
 
 /// Aggregate PublicKey for a committee of nodes. This actor listens for KeyshareCreated events
@@ -75,6 +78,7 @@ impl PublicKeyAggregator {
             params_preset: params.params_preset,
             committee_size: params.committee_size,
             dkg_fold_attestation_context: params.dkg_fold_attestation_context,
+            canonical_party_nodes: params.canonical_party_nodes,
             early_dkg_proofs: Vec::new(),
         }
     }

--- a/crates/aggregator/src/public_key_aggregation/actor.rs
+++ b/crates/aggregator/src/public_key_aggregation/actor.rs
@@ -29,7 +29,6 @@ use e3_fhe_params::BfvPreset;
 use e3_utils::NotifySync;
 use e3_utils::{ArcBytes, MAILBOX_LIMIT};
 use e3_zk_helpers::CiphernodesCommitteeSize;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
@@ -46,8 +45,6 @@ pub struct PublicKeyAggregator {
     params_preset: BfvPreset,
     committee_size: CiphernodesCommitteeSize,
     dkg_fold_attestation_context: Option<DkgFoldAttestationContext>,
-    /// Immutable finalized committee keyed by stable sortition party ID.
-    canonical_party_nodes: HashMap<u64, String>,
     /// DKG recursive aggregation events received before entering GeneratingC5Proof.
     early_dkg_proofs: Vec<TypedEvent<DKGRecursiveAggregationComplete>>,
 }
@@ -59,7 +56,6 @@ pub struct PublicKeyAggregatorParams {
     pub params_preset: BfvPreset,
     pub committee_size: CiphernodesCommitteeSize,
     pub dkg_fold_attestation_context: Option<DkgFoldAttestationContext>,
-    pub canonical_party_nodes: HashMap<u64, String>,
 }
 
 /// Aggregate PublicKey for a committee of nodes. This actor listens for KeyshareCreated events
@@ -78,7 +74,6 @@ impl PublicKeyAggregator {
             params_preset: params.params_preset,
             committee_size: params.committee_size,
             dkg_fold_attestation_context: params.dkg_fold_attestation_context,
-            canonical_party_nodes: params.canonical_party_nodes,
             early_dkg_proofs: Vec::new(),
         }
     }

--- a/crates/aggregator/src/public_key_aggregation/effects/verify_key_proofs.rs
+++ b/crates/aggregator/src/public_key_aggregation/effects/verify_key_proofs.rs
@@ -126,10 +126,6 @@ impl PublicKeyAggregator {
         let collected = submission_order.len();
         let circuit_h = circuit_committee_h;
 
-        // Retain full N committee roster (party_id → node address) for the DKG aggregator
-        // `committee_members` input, which must cover all `topNodes` regardless of honesty.
-        let full_submission_order: Vec<(u64, String, ArcBytes)> = submission_order.clone();
-
         // Filter out parties that failed C1 ZK verification. Keyed by the real
         // sortition party_id carried in `submission_order`, not arrival index.
         let mut honest_entries: Vec<(u64, String, ArcBytes, Option<SignedProofPayload>)> =
@@ -258,16 +254,15 @@ impl PublicKeyAggregator {
             ec.clone(),
         )?;
 
-        // `party_nodes` covers the FULL registered committee (all N keyshare submitters),
-        // not just the H honest set. The DKG aggregator circuit binds `committee_members`
-        // to on-chain `topNodes` which always carries the full committee — so we must keep
-        // the dishonest addresses available here to build the N-sized address vector.
-        // `submission_order` here is the unfiltered list captured pre–C1 verification
-        // (the original `VerifyingC1.submission_order`); `honest_entries` is the H subset.
-        let party_nodes: HashMap<u64, String> = full_submission_order
-            .iter()
-            .map(|(pid, node, _)| (*pid, node.clone()))
-            .collect();
+        // Proof binding uses the full immutable committee, including a member excluded before it
+        // produced a keyshare. Deriving this map from keyshare submitters would shorten the roster
+        // and make the final N-sized DKG proof impossible.
+        anyhow::ensure!(
+            self.canonical_party_nodes.len() == circuit_committee_n,
+            "finalized committee has {} entries; expected circuit N={circuit_committee_n}",
+            self.canonical_party_nodes.len()
+        );
+        let party_nodes = self.canonical_party_nodes.clone();
 
         let circuit_committee_h = circuit_h;
         self.state.try_mutate(&ec, |_| {

--- a/crates/aggregator/src/public_key_aggregation/effects/verify_key_proofs.rs
+++ b/crates/aggregator/src/public_key_aggregation/effects/verify_key_proofs.rs
@@ -3,6 +3,7 @@
 //! C1 verification and honest-keyshare selection.
 
 use super::*;
+use std::collections::HashMap;
 
 impl PublicKeyAggregator {
     pub fn add_keyshare(
@@ -111,6 +112,7 @@ impl PublicKeyAggregator {
             circuit_committee_n,
             circuit_committee_h,
             c1_proofs,
+            canonical_party_nodes,
             ..
         } = self
             .state
@@ -258,11 +260,11 @@ impl PublicKeyAggregator {
         // produced a keyshare. Deriving this map from keyshare submitters would shorten the roster
         // and make the final N-sized DKG proof impossible.
         anyhow::ensure!(
-            self.canonical_party_nodes.len() == circuit_committee_n,
+            canonical_party_nodes.len() == circuit_committee_n,
             "finalized committee has {} entries; expected circuit N={circuit_committee_n}",
-            self.canonical_party_nodes.len()
+            canonical_party_nodes.len()
         );
-        let party_nodes = self.canonical_party_nodes.clone();
+        let party_nodes = canonical_party_nodes;
 
         let circuit_committee_h = circuit_h;
         self.state.try_mutate(&ec, |_| {

--- a/crates/aggregator/src/public_key_aggregation/handlers.rs
+++ b/crates/aggregator/src/public_key_aggregation/handlers.rs
@@ -85,6 +85,48 @@ impl Handler<InterfoldEvent> for PublicKeyAggregator {
                     Ok(())
                 });
             }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                // Sortition republishes this event with a party ID. The public-key collector uses
+                // the raw event because it filters by the node address before that enrichment.
+                if data.party_id.is_some() {
+                    return;
+                }
+
+                let node_addr = data.node;
+                if data.e3_id != self.e3_id {
+                    error!("Wrong e3_id sent to PublicKeyAggregator for local exclusion.");
+                    return;
+                }
+
+                info!(
+                    node = %node_addr,
+                    e3_id = %data.e3_id,
+                    proof_type = %data.proof_type,
+                    "PublicKeyAggregator excluding a quorum-confirmed faulty member"
+                );
+                trap(EType::PublickeyAggregation, &self.bus.with_ec(&ec), || {
+                    let was_collecting = matches!(
+                        self.state.get(),
+                        Some(PublicKeyAggregatorState::Collecting { .. })
+                    );
+                    self.handle_member_expelled(node_addr, &ec)?;
+                    if was_collecting {
+                        if let Some(PublicKeyAggregatorState::VerifyingC1 {
+                            submission_order,
+                            c1_proofs,
+                            ..
+                        }) = self.state.get()
+                        {
+                            self.dispatch_c1_verification(
+                                &submission_order,
+                                &c1_proofs,
+                                ec.clone(),
+                            )?;
+                        }
+                    }
+                    Ok(())
+                });
+            }
             _ => (),
         };
     }

--- a/crates/aggregator/src/public_key_aggregation/keyshare_buffer.rs
+++ b/crates/aggregator/src/public_key_aggregation/keyshare_buffer.rs
@@ -53,6 +53,10 @@ impl KeyshareCreatedFilterBuffer {
         }
     }
 
+    fn forward(dest: &Addr<PublicKeyAggregator>, event: InterfoldEvent) {
+        dest.do_send(event);
+    }
+
     fn process_buffered_events(&mut self) {
         if !self.is_aggregator {
             return;
@@ -68,15 +72,20 @@ impl KeyshareCreatedFilterBuffer {
                                 .parse::<Address>()
                                 .is_ok_and(|node| self.expelled_nodes.contains(&node)) =>
                     {
-                        self.dest.do_send(event);
+                        Self::forward(&self.dest, event);
                     }
                     InterfoldEventData::CommitteeMemberExpelled(data)
                         if data.party_id.is_none() =>
                     {
-                        self.dest.do_send(event);
+                        Self::forward(&self.dest, event);
+                    }
+                    InterfoldEventData::CommitteeMemberExcluded(data)
+                        if data.party_id.is_none() =>
+                    {
+                        Self::forward(&self.dest, event);
                     }
                     InterfoldEventData::E3RequestComplete(_) | InterfoldEventData::Shutdown(_) => {
-                        self.dest.do_send(event);
+                        Self::forward(&self.dest, event);
                     }
                     _ => {}
                 }
@@ -106,7 +115,7 @@ impl Handler<InterfoldEvent> for KeyshareCreatedFilterBuffer {
                             .parse::<Address>()
                             .is_ok_and(|node| self.expelled_nodes.contains(&node)) =>
                 {
-                    self.dest.do_send(msg);
+                    Self::forward(&self.dest, msg);
                 }
                 None => {
                     self.buffer.push(msg);
@@ -134,7 +143,9 @@ impl Handler<InterfoldEvent> for KeyshareCreatedFilterBuffer {
                 }
 
                 let node_addr = data.node;
-                self.expelled_nodes.insert(node_addr);
+                if !self.expelled_nodes.insert(node_addr) {
+                    return;
+                }
                 self.buffer.retain(|event| {
                     !matches!(
                         event.get_data(),
@@ -151,7 +162,30 @@ impl Handler<InterfoldEvent> for KeyshareCreatedFilterBuffer {
                 }
 
                 if self.is_aggregator {
-                    self.dest.do_send(msg);
+                    Self::forward(&self.dest, msg);
+                } else {
+                    self.buffer.push(msg);
+                }
+            }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                if data.party_id.is_some() {
+                    return;
+                }
+
+                let node_addr = data.node;
+                if !self.expelled_nodes.insert(node_addr) {
+                    return;
+                }
+                self.buffer.retain(|event| {
+                    !matches!(
+                        event.get_data(),
+                        InterfoldEventData::KeyshareCreated(share)
+                            if address_matches(&share.node, node_addr)
+                    )
+                });
+
+                if self.is_aggregator {
+                    Self::forward(&self.dest, msg);
                 } else {
                     self.buffer.push(msg);
                 }
@@ -161,11 +195,11 @@ impl Handler<InterfoldEvent> for KeyshareCreatedFilterBuffer {
                 self.process_buffered_events();
             }
             InterfoldEventData::E3RequestComplete(_) | InterfoldEventData::Shutdown(_) => {
-                self.dest.do_send(msg);
+                Self::forward(&self.dest, msg);
             }
             _ => {
                 if self.is_aggregator {
-                    self.dest.do_send(msg);
+                    Self::forward(&self.dest, msg);
                 }
             }
         }

--- a/crates/aggregator/src/public_key_aggregation/state.rs
+++ b/crates/aggregator/src/public_key_aggregation/state.rs
@@ -44,9 +44,9 @@ pub enum PublicKeyAggregatorState {
         public_key: ArcBytes,
         keyshare_bytes: Vec<ArcBytes>,
         nodes: OrderedSet<String>,
-        /// Registered node address per sortition `party_id` for the **full** committee
-        /// (all `N` parties that submitted a keyshare, honest or not). Honest-only lookups
-        /// must intersect with `honest_party_ids`.
+        /// Registered node address per sortition `party_id` for the full finalized committee.
+        /// This contains all N parties even when one was excluded before submitting a keyshare.
+        /// Honest-only lookups must intersect with `honest_party_ids`.
         party_nodes: HashMap<u64, String>,
         /// DKG recursive proofs per party (restart-critical).
         dkg_node_proofs: HashMap<u64, Option<Proof>>,

--- a/crates/aggregator/src/public_key_aggregation/state.rs
+++ b/crates/aggregator/src/public_key_aggregation/state.rs
@@ -26,6 +26,9 @@ pub enum PublicKeyAggregatorState {
         /// and must be used for all downstream circuit slot indexing — arrival order
         /// is non-deterministic and does not match sortition's committee position.
         submission_order: Vec<(u64, String, ArcBytes)>,
+        /// Full finalized committee keyed by stable sortition party ID.
+        /// This roster is required to resume aggregation after a restart.
+        canonical_party_nodes: HashMap<u64, String>,
     },
     VerifyingC1 {
         /// Insertion-ordered (party_id, node, keyshare) triples from Collecting.
@@ -39,6 +42,9 @@ pub enum PublicKeyAggregatorState {
         c1_proofs: Vec<Option<SignedProofPayload>>,
         /// Real party_ids that submitted no C1 proof — treated as dishonest.
         no_proof_parties: Vec<u64>,
+        /// Full finalized committee keyed by stable sortition party ID.
+        /// This roster is required to resume aggregation after a restart.
+        canonical_party_nodes: HashMap<u64, String>,
     },
     GeneratingC5Proof {
         public_key: ArcBytes,
@@ -115,7 +121,12 @@ impl PublicKeyAggregatorState {
         }
     }
 
-    pub fn init(threshold_n: usize, threshold_m: usize, seed: Seed) -> Self {
+    pub fn init(
+        threshold_n: usize,
+        threshold_m: usize,
+        seed: Seed,
+        canonical_party_nodes: HashMap<u64, String>,
+    ) -> Self {
         let circuit_committee_h = committee_h_for(threshold_m, threshold_n)
             .unwrap_or_else(|e| panic!("invalid committee at init: {e}"));
         PublicKeyAggregatorState::Collecting {
@@ -128,6 +139,7 @@ impl PublicKeyAggregatorState {
             seed,
             nodes: OrderedSet::new(),
             submission_order: Vec::new(),
+            canonical_party_nodes,
         }
     }
 }

--- a/crates/aggregator/src/public_key_aggregation/tests/attestations.rs
+++ b/crates/aggregator/src/public_key_aggregation/tests/attestations.rs
@@ -118,6 +118,7 @@ async fn pk_aggregation_proof_pending_carries_canonical_committee_dims() -> Resu
     let fhe = Arc::new(Fhe::new(params, crp, rng));
     let (initial_state, threshold_n, threshold_m, circuit_h) =
         verifying_c1_non_square_state(&fhe, &e3_id)?;
+    let canonical_party_nodes = canonical_party_nodes(&initial_state);
 
     let mut aggregator = PublicKeyAggregator::new(
         PublicKeyAggregatorParams {
@@ -127,6 +128,7 @@ async fn pk_aggregation_proof_pending_carries_canonical_committee_dims() -> Resu
             params_preset: BfvPreset::InsecureThreshold512,
             committee_size: CiphernodesCommitteeSize::Micro,
             dkg_fold_attestation_context: None,
+            canonical_party_nodes,
         },
         test_state(initial_state),
     );
@@ -156,5 +158,62 @@ async fn pk_aggregation_proof_pending_carries_canonical_committee_dims() -> Resu
                 && data.proof_request.keyshare_bytes.len() == circuit_h
     ));
 
+    Ok(())
+}
+
+#[actix::test]
+async fn early_exclusion_keeps_full_committee_for_final_proof_binding() -> Result<()> {
+    let (bus, rng, _seed, params, crp, _errors, _history) =
+        get_common_setup(Some(BfvPreset::InsecureThreshold512.into()))?;
+    let e3_id = E3id::new("42", 1);
+    let fhe = Arc::new(Fhe::new(params, crp, rng));
+    let (mut state, threshold_n, _threshold_m, circuit_h) =
+        verifying_c1_non_square_state(&fhe, &e3_id)?;
+    let canonical_party_nodes = canonical_party_nodes(&state);
+
+    let PublicKeyAggregatorState::VerifyingC1 {
+        submission_order,
+        c1_proofs,
+        ..
+    } = &mut state
+    else {
+        unreachable!();
+    };
+    submission_order.truncate(circuit_h);
+    c1_proofs.truncate(circuit_h);
+
+    let mut aggregator = PublicKeyAggregator::new(
+        PublicKeyAggregatorParams {
+            fhe,
+            bus,
+            e3_id: e3_id.clone(),
+            params_preset: BfvPreset::InsecureThreshold512,
+            committee_size: CiphernodesCommitteeSize::Micro,
+            dkg_fold_attestation_context: None,
+            canonical_party_nodes,
+        },
+        test_state(state),
+    );
+
+    let verification = ShareVerificationComplete {
+        e3_id,
+        kind: VerificationKind::PkGenerationProofs,
+        dishonest_parties: BTreeSet::new(),
+    };
+    aggregator.handle_c1_verification_complete(TypedEvent::new(
+        verification.clone(),
+        test_ctx(verification),
+    ))?;
+
+    let Some(PublicKeyAggregatorState::GeneratingC5Proof {
+        party_nodes,
+        honest_party_ids,
+        ..
+    }) = aggregator.state.get()
+    else {
+        panic!("expected GeneratingC5Proof state");
+    };
+    assert_eq!(party_nodes.len(), threshold_n);
+    assert_eq!(honest_party_ids.len(), circuit_h);
     Ok(())
 }

--- a/crates/aggregator/src/public_key_aggregation/tests/attestations.rs
+++ b/crates/aggregator/src/public_key_aggregation/tests/attestations.rs
@@ -118,8 +118,6 @@ async fn pk_aggregation_proof_pending_carries_canonical_committee_dims() -> Resu
     let fhe = Arc::new(Fhe::new(params, crp, rng));
     let (initial_state, threshold_n, threshold_m, circuit_h) =
         verifying_c1_non_square_state(&fhe, &e3_id)?;
-    let canonical_party_nodes = canonical_party_nodes(&initial_state);
-
     let mut aggregator = PublicKeyAggregator::new(
         PublicKeyAggregatorParams {
             fhe,
@@ -128,7 +126,6 @@ async fn pk_aggregation_proof_pending_carries_canonical_committee_dims() -> Resu
             params_preset: BfvPreset::InsecureThreshold512,
             committee_size: CiphernodesCommitteeSize::Micro,
             dkg_fold_attestation_context: None,
-            canonical_party_nodes,
         },
         test_state(initial_state),
     );
@@ -169,8 +166,6 @@ async fn early_exclusion_keeps_full_committee_for_final_proof_binding() -> Resul
     let fhe = Arc::new(Fhe::new(params, crp, rng));
     let (mut state, threshold_n, _threshold_m, circuit_h) =
         verifying_c1_non_square_state(&fhe, &e3_id)?;
-    let canonical_party_nodes = canonical_party_nodes(&state);
-
     let PublicKeyAggregatorState::VerifyingC1 {
         submission_order,
         c1_proofs,
@@ -190,7 +185,6 @@ async fn early_exclusion_keeps_full_committee_for_final_proof_binding() -> Resul
             params_preset: BfvPreset::InsecureThreshold512,
             committee_size: CiphernodesCommitteeSize::Micro,
             dkg_fold_attestation_context: None,
-            canonical_party_nodes,
         },
         test_state(state),
     );

--- a/crates/aggregator/src/public_key_aggregation/tests/mod.rs
+++ b/crates/aggregator/src/public_key_aggregation/tests/mod.rs
@@ -64,6 +64,29 @@ fn complete_state() -> PublicKeyAggregatorState {
     }
 }
 
+fn canonical_party_nodes(state: &PublicKeyAggregatorState) -> HashMap<u64, String> {
+    match state {
+        PublicKeyAggregatorState::Collecting {
+            submission_order, ..
+        }
+        | PublicKeyAggregatorState::VerifyingC1 {
+            submission_order, ..
+        } => submission_order
+            .iter()
+            .map(|(party_id, node, _)| (*party_id, node.clone()))
+            .collect(),
+        PublicKeyAggregatorState::GeneratingC5Proof { party_nodes, .. } => party_nodes.clone(),
+        PublicKeyAggregatorState::Complete {
+            committee_addresses,
+            ..
+        } => committee_addresses
+            .iter()
+            .enumerate()
+            .map(|(party_id, node)| (party_id as u64, node.to_string()))
+            .collect(),
+    }
+}
+
 async fn build_public_key_aggregator(
     initial_state: PublicKeyAggregatorState,
 ) -> Result<(
@@ -87,6 +110,7 @@ async fn build_public_key_aggregator_with_committee(
         get_common_setup(Some(BfvPreset::InsecureThreshold512.into()))?;
     let e3_id = E3id::new("42", 1);
     let fhe = Arc::new(Fhe::new(params, crp, rng));
+    let canonical_party_nodes = canonical_party_nodes(&initial_state);
     let aggregator = PublicKeyAggregator::new(
         PublicKeyAggregatorParams {
             fhe,
@@ -95,6 +119,7 @@ async fn build_public_key_aggregator_with_committee(
             params_preset: BfvPreset::InsecureThreshold512,
             committee_size,
             dkg_fold_attestation_context: None,
+            canonical_party_nodes,
         },
         test_state(initial_state),
     );

--- a/crates/aggregator/src/public_key_aggregation/tests/mod.rs
+++ b/crates/aggregator/src/public_key_aggregation/tests/mod.rs
@@ -11,7 +11,7 @@ use e3_events::{
     Unsequenced, ZkError,
 };
 use e3_test_helpers::get_common_setup;
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 fn test_ctx(data: impl Into<InterfoldEventData>) -> EventContext<Sequenced> {
     EventContext::<Unsequenced>::from(data.into()).sequence(0)
@@ -64,29 +64,6 @@ fn complete_state() -> PublicKeyAggregatorState {
     }
 }
 
-fn canonical_party_nodes(state: &PublicKeyAggregatorState) -> HashMap<u64, String> {
-    match state {
-        PublicKeyAggregatorState::Collecting {
-            submission_order, ..
-        }
-        | PublicKeyAggregatorState::VerifyingC1 {
-            submission_order, ..
-        } => submission_order
-            .iter()
-            .map(|(party_id, node, _)| (*party_id, node.clone()))
-            .collect(),
-        PublicKeyAggregatorState::GeneratingC5Proof { party_nodes, .. } => party_nodes.clone(),
-        PublicKeyAggregatorState::Complete {
-            committee_addresses,
-            ..
-        } => committee_addresses
-            .iter()
-            .enumerate()
-            .map(|(party_id, node)| (party_id as u64, node.to_string()))
-            .collect(),
-    }
-}
-
 async fn build_public_key_aggregator(
     initial_state: PublicKeyAggregatorState,
 ) -> Result<(
@@ -110,7 +87,6 @@ async fn build_public_key_aggregator_with_committee(
         get_common_setup(Some(BfvPreset::InsecureThreshold512.into()))?;
     let e3_id = E3id::new("42", 1);
     let fhe = Arc::new(Fhe::new(params, crp, rng));
-    let canonical_party_nodes = canonical_party_nodes(&initial_state);
     let aggregator = PublicKeyAggregator::new(
         PublicKeyAggregatorParams {
             fhe,
@@ -119,7 +95,6 @@ async fn build_public_key_aggregator_with_committee(
             params_preset: BfvPreset::InsecureThreshold512,
             committee_size,
             dkg_fold_attestation_context: None,
-            canonical_party_nodes,
         },
         test_state(initial_state),
     );
@@ -163,10 +138,12 @@ fn verifying_c1_non_square_state(
 
     let mut submission_order = Vec::with_capacity(threshold_n);
     let mut c1_proofs = Vec::with_capacity(threshold_n);
+    let mut canonical_party_nodes = HashMap::with_capacity(threshold_n);
     let mut rng = rand::rng();
 
     for party_id in 0..threshold_n as u64 {
         let node = format!("0x{:040x}", party_id + 1);
+        canonical_party_nodes.insert(party_id, node.clone());
         if party_id < circuit_h as u64 {
             let sk = SecretKey::random(&fhe.params, &mut rng);
             let pk_share = PublicKeyShare::new(&sk, fhe.crp.clone(), &mut rng)?;
@@ -192,6 +169,7 @@ fn verifying_c1_non_square_state(
             circuit_committee_h: circuit_h,
             c1_proofs,
             no_proof_parties: vec![],
+            canonical_party_nodes,
         },
         threshold_n,
         threshold_m,

--- a/crates/aggregator/src/public_key_aggregation/transitions.rs
+++ b/crates/aggregator/src/public_key_aggregation/transitions.rs
@@ -26,9 +26,9 @@ pub(crate) enum HonestSelection {
 pub(crate) struct PublicKeyAggregation;
 
 impl PublicKeyAggregation {
-    /// Add a keyshare to a `Collecting` state, returning the next state. When all `N`
-    /// committee keyshares have arrived this transitions to `VerifyingC1`. Submitting a
-    /// `party_id` that already has a keyshare is idempotent (state is returned unchanged).
+    /// Add a keyshare to a `Collecting` state. When every currently expected party has submitted,
+    /// this transitions to `VerifyingC1`. The expected count starts at N and decreases after an
+    /// E3-scoped exclusion. Reusing a `party_id` is idempotent.
     pub(crate) fn add_keyshare(
         mut state: PublicKeyAggregatorState,
         keyshare: ArcBytes,

--- a/crates/aggregator/src/public_key_aggregation/transitions.rs
+++ b/crates/aggregator/src/public_key_aggregation/transitions.rs
@@ -45,6 +45,7 @@ impl PublicKeyAggregation {
             c1_proofs,
             nodes,
             submission_order,
+            canonical_party_nodes,
             ..
         } = &mut state
         else {
@@ -84,6 +85,7 @@ impl PublicKeyAggregation {
                 circuit_committee_h: committee_h,
                 c1_proofs: std::mem::take(c1_proofs),
                 no_proof_parties: Vec::new(),
+                canonical_party_nodes: std::mem::take(canonical_party_nodes),
             });
         }
 
@@ -202,6 +204,7 @@ impl PublicKeyAggregation {
             c1_proofs,
             nodes,
             submission_order,
+            canonical_party_nodes,
             ..
         } = &mut state
         else {
@@ -260,6 +263,7 @@ impl PublicKeyAggregation {
                 circuit_committee_h: committee_h,
                 c1_proofs: std::mem::take(c1_proofs),
                 no_proof_parties: Vec::new(),
+                canonical_party_nodes: std::mem::take(canonical_party_nodes),
             });
         }
 

--- a/crates/aggregator/src/public_key_aggregation/workflow_tests.rs
+++ b/crates/aggregator/src/public_key_aggregation/workflow_tests.rs
@@ -11,7 +11,15 @@ fn ks(byte: u8) -> ArcBytes {
 }
 
 fn collecting(threshold_n: usize, threshold_m: usize) -> PublicKeyAggregatorState {
-    PublicKeyAggregatorState::init(threshold_n, threshold_m, Seed([0u8; 32]))
+    let canonical_party_nodes = (0..threshold_n as u64)
+        .map(|party_id| (party_id, format!("node-{party_id}")))
+        .collect();
+    PublicKeyAggregatorState::init(
+        threshold_n,
+        threshold_m,
+        Seed([0u8; 32]),
+        canonical_party_nodes,
+    )
 }
 
 #[test]
@@ -65,12 +73,14 @@ fn add_keyshare_reaching_threshold_transitions_to_verifying_c1() {
             circuit_committee_n,
             circuit_committee_h,
             threshold_m,
+            canonical_party_nodes,
             ..
         } => {
             assert_eq!(submission_order.len(), 3);
             assert_eq!(circuit_committee_n, 3);
             assert_eq!(circuit_committee_h, 2);
             assert_eq!(threshold_m, 1);
+            assert_eq!(canonical_party_nodes.len(), 3);
         }
         _ => panic!("expected VerifyingC1"),
     }
@@ -85,6 +95,7 @@ fn add_keyshare_wrong_state_errors() {
         circuit_committee_h: 2,
         c1_proofs: vec![],
         no_proof_parties: vec![],
+        canonical_party_nodes: HashMap::new(),
     };
     let err = PublicKeyAggregation::add_keyshare(state, ks(1), "n".into(), 0, None);
     assert!(err.is_err());
@@ -217,6 +228,11 @@ fn handle_member_expelled_transitions_when_enough_remain() {
                 ks(11),
             ),
         ],
+        canonical_party_nodes: HashMap::from([
+            (0, "0xabcdef0000000000000000000000000000000000".to_string()),
+            (1, "0x2222222222222222222222222222222222222222".to_string()),
+            (2, "0x3333333333333333333333333333333333333333".to_string()),
+        ]),
     };
     let next = PublicKeyAggregation::handle_member_expelled(
         state,
@@ -230,11 +246,13 @@ fn handle_member_expelled_transitions_when_enough_remain() {
             circuit_committee_n,
             circuit_committee_h,
             submission_order,
+            canonical_party_nodes,
             ..
         } => {
             assert_eq!(circuit_committee_n, 3);
             assert_eq!(circuit_committee_h, 2);
             assert_eq!(submission_order.len(), 1);
+            assert_eq!(canonical_party_nodes.len(), 3);
         }
         _ => panic!("expected VerifyingC1"),
     }

--- a/crates/events/src/interfold_event/ciphernode_selected.rs
+++ b/crates/events/src/interfold_event/ciphernode_selected.rs
@@ -22,6 +22,8 @@ pub struct CiphernodeSelected {
     pub params_preset: BfvPreset,
     pub params: ArcBytes,
     pub party_id: u64,
+    /// Full finalized committee in stable party-ID order.
+    pub committee: Vec<String>,
 }
 
 impl Default for CiphernodeSelected {
@@ -32,6 +34,7 @@ impl Default for CiphernodeSelected {
             params_preset: BfvPreset::InsecureThreshold512,
             params: ArcBytes::from_bytes(&[]),
             party_id: 0,
+            committee: Vec::new(),
             seed: Seed([0u8; 32]),
             threshold_m: 0,
             threshold_n: 0,

--- a/crates/events/src/interfold_event/committee_member_excluded.rs
+++ b/crates/events/src/interfold_event/committee_member_excluded.rs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+use crate::{E3id, ProofType};
+use actix::Message;
+use alloy::primitives::Address;
+use serde::{Deserialize, Serialize};
+use std::fmt::{self, Display};
+
+/// Records an E3-scoped exclusion after the committee confirms a proof fault and the matching
+/// on-chain slash policy is disabled.
+///
+/// This event does not mean that the node was slashed, banned, or removed from the on-chain
+/// committee. It lets the current E3 stop waiting for known-bad work without changing the
+/// canonical committee roster used by proofs.
+#[derive(Message, Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[rtype(result = "()")]
+pub struct CommitteeMemberExcluded {
+    /// The E3 computation that excludes the member.
+    pub e3_id: E3id,
+    /// Address of the excluded committee member.
+    pub node: Address,
+    /// The proof type confirmed as faulty by accusation quorum.
+    pub proof_type: ProofType,
+    /// Party ID in the finalized committee.
+    ///
+    /// This is `None` when the slashing writer creates the event. Sortition resolves the stable
+    /// party ID and republishes the event with `Some(id)` for downstream actors.
+    pub party_id: Option<u64>,
+}
+
+impl Display for CommitteeMemberExcluded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "CommitteeMemberExcluded {{ e3_id: {}, node: {}, proof_type: {}, party_id: {:?} }}",
+            self.e3_id, self.node, self.proof_type, self.party_id
+        )
+    }
+}

--- a/crates/events/src/interfold_event/mod.rs
+++ b/crates/events/src/interfold_event/mod.rs
@@ -21,6 +21,7 @@ mod committee_activation_changed;
 mod committee_finalize_requested;
 mod committee_finalized;
 mod committee_formation_failed;
+mod committee_member_excluded;
 mod committee_published;
 mod committee_requested;
 mod committee_viability_updated;
@@ -100,6 +101,7 @@ pub use committee_activation_changed::*;
 pub use committee_finalize_requested::*;
 pub use committee_finalized::*;
 pub use committee_formation_failed::*;
+pub use committee_member_excluded::*;
 pub use committee_published::*;
 pub use committee_requested::*;
 pub use committee_viability_updated::*;
@@ -347,6 +349,8 @@ pub enum InterfoldEventData {
     EvmLogObserved(EvmLogObserved),
     BondOwnerSet(BondOwnerSet),
     DkgFoldAttestationContextEstablished(DkgFoldAttestationContextEstablished),
+    // Append new durable variants to preserve existing enum discriminants in persisted logs.
+    CommitteeMemberExcluded(CommitteeMemberExcluded),
 }
 
 impl InterfoldEventData {
@@ -638,6 +642,7 @@ impl InterfoldEventData {
             InterfoldEventData::ShareVerificationComplete(ref data) => Some(data.e3_id.clone()),
             InterfoldEventData::SlashExecuted(ref data) => Some(data.e3_id.clone()),
             InterfoldEventData::CommitteeMemberExpelled(ref data) => Some(data.e3_id.clone()),
+            InterfoldEventData::CommitteeMemberExcluded(ref data) => Some(data.e3_id.clone()),
             InterfoldEventData::E3Failed(ref data) => Some(data.e3_id.clone()),
             InterfoldEventData::E3StageChanged(ref data) => Some(data.e3_id.clone()),
             InterfoldEventData::DecryptionShareProofSigned(ref data) => Some(data.e3_id.clone()),
@@ -780,7 +785,8 @@ impl_event_types!(
     CommitteeViabilityUpdated,
     EvmLogObserved,
     BondOwnerSet,
-    DkgFoldAttestationContextEstablished
+    DkgFoldAttestationContextEstablished,
+    CommitteeMemberExcluded
 );
 
 impl TryFrom<&InterfoldEvent<Sequenced>> for InterfoldError {

--- a/crates/evm/src/contracts.rs
+++ b/crates/evm/src/contracts.rs
@@ -80,6 +80,18 @@ sol! {
     #[sol(rpc)]
     #[derive(Debug)]
     interface ISlashingManager {
+        struct SlashPolicy {
+            uint256 ticketPenalty;
+            uint256 ciphernodeBondPenalty;
+            bool requiresProof;
+            address proofVerifier;
+            bool banNode;
+            uint256 appealWindow;
+            bool enabled;
+            bool affectsCommittee;
+            uint8 failureReason;
+        }
+
         // ── Write functions ─────────────────────────────────────────────────
         function proposeSlash(
             uint256 e3Id,
@@ -95,6 +107,8 @@ sol! {
 
         // ── View functions ──────────────────────────────────────────────────
         function ciphernodeRegistry() external view returns (address);
+
+        function getSlashPolicy(bytes32 reason) external view returns (SlashPolicy memory policy);
 
         // ── Events ──────────────────────────────────────────────────────────
         event SlashExecuted(

--- a/crates/evm/src/slashing_writing/actor.rs
+++ b/crates/evm/src/slashing_writing/actor.rs
@@ -13,8 +13,9 @@ use crate::contracts::{ICiphernodeRegistry, ISlashingManager};
 use crate::domain::attestation_evidence::encode_attestation_evidence;
 use crate::domain::error_decoder::format_evm_error;
 use crate::domain::slash_submission::{
-    should_submit_slash, submission_delay, submission_rank, SlashIntentKey,
-    SlashSubmissionDecision, SlashSubmissionGate,
+    classify_slash_policy, is_slashable_outcome, should_submit_slash, slash_reason,
+    submission_delay, submission_rank, SlashIntentKey, SlashPolicyState, SlashSubmissionDecision,
+    SlashSubmissionGate,
 };
 use crate::helpers::{transaction_nonce_guard, EthProvider};
 use crate::send_tx_with_retry;
@@ -32,7 +33,7 @@ use e3_events::EventType;
 use e3_events::InterfoldEvent;
 use e3_events::InterfoldEventData;
 use e3_events::Shutdown;
-use e3_events::{AccusationQuorumReached, EType};
+use e3_events::{AccusationQuorumReached, CommitteeMemberExcluded, EType};
 use e3_utils::{require_successful_receipt, NotifySync, MAILBOX_LIMIT};
 use tracing::{info, warn};
 
@@ -86,6 +87,7 @@ impl<P: Provider + WalletProvider + Clone + 'static> SlashingManagerSolWriter<P>
         bus.subscribe_all(
             &[
                 EventType::AccusationQuorumReached,
+                EventType::CommitteeMemberExcluded,
                 EventType::EffectsEnabled,
                 EventType::Shutdown,
             ],

--- a/crates/evm/src/slashing_writing/effects.rs
+++ b/crates/evm/src/slashing_writing/effects.rs
@@ -4,6 +4,20 @@
 
 use super::*;
 
+pub(in crate::actors::slashing_manager_sol_writer) async fn read_slash_policy<
+    P: Provider + WalletProvider + Clone,
+>(
+    provider: EthProvider<P>,
+    contract_address: Address,
+    proof_type: u8,
+) -> Result<ISlashingManager::SlashPolicy> {
+    let contract = ISlashingManager::new(contract_address, provider.provider());
+    Ok(contract
+        .getSlashPolicy(slash_reason(proof_type))
+        .call()
+        .await?)
+}
+
 pub(in crate::actors::slashing_manager_sol_writer) async fn submit_slash_proposal<
     P: Provider + WalletProvider + Clone,
 >(

--- a/crates/evm/src/slashing_writing/handlers.rs
+++ b/crates/evm/src/slashing_writing/handlers.rs
@@ -2,7 +2,7 @@
 
 //! Admission, scheduling, and submission-outcome handlers.
 
-use super::effects::submit_slash_proposal;
+use super::effects::{read_slash_policy, submit_slash_proposal};
 use super::*;
 
 impl<P: Provider + WalletProvider + Clone + 'static> Handler<InterfoldEvent>
@@ -13,33 +13,12 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<InterfoldEvent>
     fn handle(&mut self, msg: InterfoldEvent, ctx: &mut Self::Context) -> Self::Result {
         match msg.into_data() {
             InterfoldEventData::AccusationQuorumReached(data) => {
-                // Only submit if:
-                // 1. This is the right chain
-                // 2. The quorum decided the accused is at fault OR equivocated
-                // 3. This node is among the top MAX_SLASH_SUBMITTERS voters
-                //    (sorted ascending by address). The lowest-address voter
-                //    submits immediately; higher-ranked fallback voters wait
-                //    progressively longer (rank * SUBMITTER_DELAY_SECS) before
-                //    attempting submission. On-chain DuplicateEvidence protection
-                //    ensures at most one slash executes.
-                let my_addr = self.provider.provider().default_signer_address();
-                let rank = submission_rank(data.votes_for.iter().map(|v| v.voter), my_addr);
-
-                if should_submit_slash(
-                    self.provider.chain_id() == data.e3_id.chain_id(),
-                    &data.outcome,
-                    rank,
-                ) {
-                    if encode_attestation_evidence(&data).is_none() {
-                        self.bus.err(
-                            EType::Evm,
-                            anyhow::anyhow!(
-                                "Refusing malformed slash intent for E3 {}: votes or evidence are empty",
-                                data.e3_id
-                            ),
-                        );
-                        return;
-                    }
+                // Every node evaluates the policy after quorum. Only the first three voters send
+                // a transaction when Lane A is enabled, but all nodes need the same disabled-policy
+                // decision so they can derive the same E3-scoped exclusion.
+                if self.provider.chain_id() == data.e3_id.chain_id()
+                    && is_slashable_outcome(&data.outcome)
+                {
                     match self.submissions.admit(data.clone()) {
                         Ok((key, SlashSubmissionDecision::Submit)) => {
                             ctx.notify(SubmitSlashIntent { key, event: data });
@@ -50,6 +29,14 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<InterfoldEvent>
                         Ok((_, SlashSubmissionDecision::IgnoreDuplicate)) => {
                             info!(e3_id = %data.e3_id, "Ignored duplicate slash intent");
                         }
+                        Err(error) => self.bus.err(EType::Evm, error),
+                    }
+                }
+            }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                if data.e3_id.chain_id() == self.provider.chain_id() {
+                    match SlashIntentKey::from_exclusion(&data) {
+                        Ok(key) => self.submissions.mark_completed(key),
                         Err(error) => self.bus.err(EType::Evm, error),
                     }
                 }
@@ -97,9 +84,103 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<SubmitSlashIntent>
             let address = ctx.address();
             async move {
                 let SubmitSlashIntent { key, event: msg } = msg;
-                // Compute this node's submission rank for staggered fallback
-                let rank =
-                    submission_rank(msg.votes_for.iter().map(|v| v.voter), my_addr).unwrap_or(0);
+                let rank = submission_rank(msg.votes_for.iter().map(|v| v.voter), my_addr);
+
+                let policy =
+                    read_slash_policy(provider.clone(), contract_address, msg.proof_type as u8)
+                        .await;
+
+                match policy {
+                    Ok(policy)
+                        if classify_slash_policy(policy.enabled, policy.requiresProof)
+                            == SlashPolicyState::Disabled =>
+                    {
+                        info!(
+                            e3_id = %msg.e3_id,
+                            accused = %msg.accused,
+                            proof_type = %msg.proof_type,
+                            reason = %slash_reason(msg.proof_type as u8),
+                            "Slash policy is disabled; excluding the faulted member from local E3 work"
+                        );
+                        if let Err(error) = bus.publish_without_context(CommitteeMemberExcluded {
+                            e3_id: msg.e3_id.clone(),
+                            node: msg.accused,
+                            proof_type: msg.proof_type,
+                            party_id: None,
+                        }) {
+                            bus.err(EType::Evm, error);
+                            let _ = address
+                                .send(SlashSubmissionFinished {
+                                    key,
+                                    terminal: false,
+                                })
+                                .await;
+                            return;
+                        }
+                        let _ = address
+                            .send(SlashSubmissionFinished {
+                                key,
+                                terminal: true,
+                            })
+                            .await;
+                        return;
+                    }
+                    Ok(policy)
+                        if classify_slash_policy(policy.enabled, policy.requiresProof)
+                            == SlashPolicyState::InvalidForAttestations =>
+                    {
+                        bus.err(
+                            EType::Evm,
+                            anyhow::anyhow!(
+                                "Slash policy for proof type {} is enabled but does not accept committee attestations",
+                                msg.proof_type
+                            ),
+                        );
+                        let _ = address
+                            .send(SlashSubmissionFinished {
+                                key,
+                                terminal: true,
+                            })
+                            .await;
+                        return;
+                    }
+                    Err(error) => {
+                        // A failed read must not invent an exclusion. Eligible submitters retain the
+                        // previous transaction path so a temporary RPC read failure cannot suppress
+                        // an enabled slash.
+                        warn!(%error, "Could not read slash policy before submission");
+                    }
+                    Ok(_) => {}
+                }
+
+                if !should_submit_slash(true, &msg.outcome, rank) {
+                    let _ = address
+                        .send(SlashSubmissionFinished {
+                            key,
+                            terminal: true,
+                        })
+                        .await;
+                    return;
+                }
+
+                if encode_attestation_evidence(&msg).is_none() {
+                    bus.err(
+                        EType::Evm,
+                        anyhow::anyhow!(
+                            "Refusing malformed slash intent for E3 {}: votes or evidence are empty",
+                            msg.e3_id
+                        ),
+                    );
+                    let _ = address
+                        .send(SlashSubmissionFinished {
+                            key,
+                            terminal: true,
+                        })
+                        .await;
+                    return;
+                }
+
+                let rank = rank.expect("submission decision requires a voter rank");
 
                 // Fallback submitters wait before attempting, giving the primary
                 // submitter time to land the transaction on-chain.

--- a/crates/evm/src/slashing_writing/workflow.rs
+++ b/crates/evm/src/slashing_writing/workflow.rs
@@ -6,20 +6,20 @@
 
 //! Pure decision logic for staggered, committee-attested slash submission.
 //!
-//! A node only submits a slash proposal when it is one of the top
-//! `MAX_SLASH_SUBMITTERS` voters (ranked ascending by signer address). The
-//! lowest-address voter submits immediately; higher-ranked fallback voters wait
-//! `rank * SUBMITTER_DELAY_SECS` so on-chain `DuplicateEvidence` protection lets
-//! at most one slash execute.
+//! Every node checks the proof-type policy after an accusation quorum. When the policy accepts
+//! proof attestations, only the top `MAX_SLASH_SUBMITTERS` voters can submit a slash proposal.
+//! The lowest-address voter submits immediately. Higher-ranked fallback voters wait
+//! `rank * SUBMITTER_DELAY_SECS`, and on-chain `DuplicateEvidence` protection limits execution to
+//! one proposal.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
     time::Duration,
 };
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{keccak256, Address, B256, U256};
 use anyhow::{Context, Result};
-use e3_events::{AccusationOutcome, AccusationQuorumReached};
+use e3_events::{AccusationOutcome, AccusationQuorumReached, CommitteeMemberExcluded};
 
 /// Maximum number of voters eligible to attempt on-chain submission.
 /// Rank 0 submits immediately, rank 1 after one delay interval, etc.
@@ -50,6 +50,19 @@ impl SlashIntentKey {
                 .try_into()
                 .context("slash intent has a non-numeric E3 id")?,
             operator: event.accused,
+            proof_type: event.proof_type as u8,
+        })
+    }
+
+    pub(crate) fn from_exclusion(event: &CommitteeMemberExcluded) -> Result<Self> {
+        Ok(Self {
+            chain_id: event.e3_id.chain_id(),
+            e3_id: event
+                .e3_id
+                .clone()
+                .try_into()
+                .context("committee exclusion has a non-numeric E3 id")?,
+            operator: event.node,
             proof_type: event.proof_type as u8,
         })
     }
@@ -124,6 +137,12 @@ impl SlashSubmissionGate {
             self.completed.insert(key.clone());
         }
     }
+
+    pub(crate) fn mark_completed(&mut self, key: SlashIntentKey) {
+        self.deferred.remove(&key);
+        self.in_flight.remove(&key);
+        self.completed.insert(key);
+    }
 }
 
 /// Determine this node's submission rank: its position in the voter set after
@@ -140,6 +159,26 @@ where
 /// Outcomes that warrant an on-chain slash proposal.
 pub(crate) fn is_slashable_outcome(outcome: &AccusationOutcome) -> bool {
     matches!(outcome, AccusationOutcome::AccusedFaulted)
+}
+
+/// Derive the policy key exactly as `SlashingManager._proposeSlash` does for Lane A evidence.
+pub(crate) fn slash_reason(proof_type: u8) -> B256 {
+    keccak256(U256::from(proof_type).to_be_bytes::<32>())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SlashPolicyState {
+    Disabled,
+    ProofEnabled,
+    InvalidForAttestations,
+}
+
+pub(crate) fn classify_slash_policy(enabled: bool, requires_proof: bool) -> SlashPolicyState {
+    match (enabled, requires_proof) {
+        (false, _) => SlashPolicyState::Disabled,
+        (true, true) => SlashPolicyState::ProofEnabled,
+        (true, false) => SlashPolicyState::InvalidForAttestations,
+    }
 }
 
 /// Whether this node should attempt submission for the given quorum result.
@@ -238,6 +277,58 @@ mod tests {
             &AccusationOutcome::Equivocation,
             Some(0)
         ));
+    }
+
+    #[test]
+    fn slash_reason_matches_uint256_packed_encoding() {
+        assert_eq!(
+            slash_reason(1),
+            keccak256([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ])
+        );
+    }
+
+    #[test]
+    fn persisted_local_exclusion_suppresses_a_deferred_replay() {
+        let event = quorum(vec![Address::repeat_byte(1)]);
+        let exclusion = CommitteeMemberExcluded {
+            e3_id: event.e3_id.clone(),
+            node: event.accused,
+            proof_type: event.proof_type,
+            party_id: Some(0),
+        };
+        let key = SlashIntentKey::from_exclusion(&exclusion).unwrap();
+        let mut gate = SlashSubmissionGate::new();
+
+        assert_eq!(
+            gate.admit(event.clone()).unwrap().1,
+            SlashSubmissionDecision::Defer
+        );
+        gate.mark_completed(key);
+
+        assert!(gate.enable_effects().is_empty());
+        assert_eq!(
+            gate.admit(event).unwrap().1,
+            SlashSubmissionDecision::IgnoreDuplicate
+        );
+    }
+
+    #[test]
+    fn disabled_policy_is_distinct_from_invalid_lane_configuration() {
+        assert_eq!(
+            classify_slash_policy(false, false),
+            SlashPolicyState::Disabled
+        );
+        assert_eq!(
+            classify_slash_policy(true, false),
+            SlashPolicyState::InvalidForAttestations
+        );
+        assert_eq!(
+            classify_slash_policy(true, true),
+            SlashPolicyState::ProofEnabled
+        );
     }
 
     #[test]

--- a/crates/keyshare/src/threshold_keyshare/actor.rs
+++ b/crates/keyshare/src/threshold_keyshare/actor.rs
@@ -11,15 +11,16 @@ use e3_crypto::{Cipher, SensitiveBytes};
 use e3_data::Persistable;
 use e3_events::{
     prelude::*, trap, BusHandle, CiphernodeSelected, CiphertextOutputPublished,
-    CommitteeMemberExpelled, ComputeRequest, ComputeResponse, ComputeResponseKind, CorrelationId,
-    DecryptionKeyShared, DecryptionShareProofSigned, DecryptionShareProofsPending, Die,
-    DkgProofSigned, DkgShareDecryptionProofRequest, E3Failed, E3RequestComplete, E3Stage, EType,
-    EncryptionKey, EncryptionKeyCollectionFailed, EncryptionKeyCreated, EncryptionKeyPending,
-    EventContext, FailureReason, InterfoldEvent, InterfoldEventData, KeyshareCreated,
-    PartyProofsToVerify, PartyShareDecryptionProofsToVerify, PkGenerationProofSigned, ProofType,
-    Sequenced, ShareDecryptionProofPending, ShareVerificationComplete, ShareVerificationDispatched,
-    SignedProofPayload, ThresholdShare, ThresholdShareCollectionFailed, ThresholdShareCreated,
-    ThresholdShareDecryptionProofRequest, ThresholdSharePending, TypedEvent, VerificationKind,
+    CommitteeMemberExcluded, CommitteeMemberExpelled, ComputeRequest, ComputeResponse,
+    ComputeResponseKind, CorrelationId, DecryptionKeyShared, DecryptionShareProofSigned,
+    DecryptionShareProofsPending, Die, DkgProofSigned, DkgShareDecryptionProofRequest, E3Failed,
+    E3RequestComplete, E3Stage, EType, EncryptionKey, EncryptionKeyCollectionFailed,
+    EncryptionKeyCreated, EncryptionKeyPending, EventContext, FailureReason, InterfoldEvent,
+    InterfoldEventData, KeyshareCreated, PartyProofsToVerify, PartyShareDecryptionProofsToVerify,
+    PkGenerationProofSigned, ProofType, Sequenced, ShareDecryptionProofPending,
+    ShareVerificationComplete, ShareVerificationDispatched, SignedProofPayload, ThresholdShare,
+    ThresholdShareCollectionFailed, ThresholdShareCreated, ThresholdShareDecryptionProofRequest,
+    ThresholdSharePending, TypedEvent, VerificationKind,
 };
 use e3_fhe_params::create_deterministic_crp_from_default_seed;
 use e3_fhe_params::BfvPreset;

--- a/crates/keyshare/src/threshold_keyshare/effects/coordinate_collectors.rs
+++ b/crates/keyshare/src/threshold_keyshare/effects/coordinate_collectors.rs
@@ -127,6 +127,30 @@ impl ThresholdKeyshare {
             node_addr, party_id, data.e3_id, data.active_count_after
         );
 
+        self.handle_party_excluded(party_id, ec);
+    }
+
+    pub(in crate::actors::threshold_keyshare) fn handle_committee_member_excluded(
+        &mut self,
+        data: CommitteeMemberExcluded,
+        ec: EventContext<Sequenced>,
+    ) {
+        let Some(party_id) = data.party_id else {
+            return;
+        };
+
+        info!(
+            node = %data.node,
+            party_id,
+            e3_id = %data.e3_id,
+            proof_type = %data.proof_type,
+            "Stopping current E3 work with a quorum-confirmed faulty member"
+        );
+
+        self.handle_party_excluded(party_id, ec);
+    }
+
+    fn handle_party_excluded(&mut self, party_id: u64, ec: EventContext<Sequenced>) {
         // Record permanently so late-arriving data is rejected even if
         // collectors haven't been created or have already completed.
         // Also clean honest_parties set for the expelled party.

--- a/crates/keyshare/src/threshold_keyshare/effects/route_events.rs
+++ b/crates/keyshare/src/threshold_keyshare/effects/route_events.rs
@@ -145,6 +145,9 @@ impl Handler<InterfoldEvent> for ThresholdKeyshare {
             InterfoldEventData::CommitteeMemberExpelled(data) => {
                 self.handle_committee_member_expelled(data, ec);
             }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                self.handle_committee_member_excluded(data, ec);
+            }
             InterfoldEventData::EffectsEnabled(_) => {
                 // Broadcast once at the end of boot sync. Re-drive any of this node's own
                 // in-flight work that a crash may have interrupted (idempotent downstream).

--- a/crates/sortition/src/ciphernode_selection/actor.rs
+++ b/crates/sortition/src/ciphernode_selection/actor.rs
@@ -15,8 +15,8 @@ use e3_events::Sequenced;
 use e3_events::TypedEvent;
 use e3_events::{
     prelude::*, trap, AggregatorChanged, BusHandle, CiphernodeSelected, Committee,
-    CommitteeFinalized, CommitteeMemberExpelled, E3Requested, E3id, EType, EventType,
-    InterfoldEvent, InterfoldEventData, Shutdown, TicketGenerated, TicketId,
+    CommitteeFinalized, CommitteeMemberExcluded, CommitteeMemberExpelled, E3Requested, E3id, EType,
+    EventType, InterfoldEvent, InterfoldEventData, Shutdown, TicketGenerated, TicketId,
 };
 use e3_request::E3Meta;
 use e3_utils::NotifySync;
@@ -44,6 +44,8 @@ fn e3_meta_from(req: &E3Requested) -> E3Meta {
 pub struct CiphernodeSelectorState {
     pub e3_cache: HashMap<E3id, E3Meta>,
     pub committees: HashMap<E3id, Committee>,
+    /// Party IDs excluded from current E3 work by an on-chain expulsion or a confirmed local
+    /// fallback. This does not alter the canonical committee roster.
     pub expelled: HashMap<E3id, Vec<u64>>,
     /// Party ids the local node presumes unresponsive for failover purposes.
     /// Treated identically to `expelled` when computing the active aggregator,
@@ -99,6 +101,7 @@ impl CiphernodeSelector {
         bus.subscribe(EventType::E3RequestComplete, addr.clone().recipient());
         bus.subscribe(EventType::CommitteeFinalized, addr.clone().recipient());
         bus.subscribe(EventType::CommitteeMemberExpelled, addr.clone().recipient());
+        bus.subscribe(EventType::CommitteeMemberExcluded, addr.clone().recipient());
         bus.subscribe(EventType::Shutdown, addr.clone().recipient());
 
         info!("CiphernodeSelector listening!");

--- a/crates/sortition/src/ciphernode_selection/handlers.rs
+++ b/crates/sortition/src/ciphernode_selection/handlers.rs
@@ -21,6 +21,9 @@ impl Handler<InterfoldEvent> for CiphernodeSelector {
             InterfoldEventData::CommitteeMemberExpelled(data) => {
                 self.notify_sync(ctx, TypedEvent::new(data, ec))
             }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                self.notify_sync(ctx, TypedEvent::new(data, ec))
+            }
             InterfoldEventData::Shutdown(data) => self.notify_sync(ctx, data),
             _ => (),
         }
@@ -182,6 +185,7 @@ impl Handler<TypedEvent<CommitteeFinalized>> for CiphernodeSelector {
                             params_preset: e3_meta.params_preset,
                             params: e3_meta.params.clone(),
                             seed: e3_meta.seed,
+                            committee: msg.committee.clone(),
                         },
                         ec.clone(),
                     )?;
@@ -216,6 +220,34 @@ impl Handler<TypedEvent<CommitteeMemberExpelled>> for CiphernodeSelector {
                 if !expelled.contains(&party_id) {
                     expelled.push(party_id);
                     expelled.sort_unstable();
+                }
+                Ok(state)
+            })?;
+
+            self.update_aggregator_status(&msg.e3_id, &ec, false)
+        })
+    }
+}
+
+impl Handler<TypedEvent<CommitteeMemberExcluded>> for CiphernodeSelector {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        msg: TypedEvent<CommitteeMemberExcluded>,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        trap(EType::Sortition, &self.bus.with_ec(msg.get_ctx()), || {
+            let (msg, ec) = msg.into_components();
+            let Some(party_id) = msg.party_id else {
+                return Ok(());
+            };
+
+            self.state.try_mutate(&ec, |mut state| {
+                let excluded = state.expelled.entry(msg.e3_id.clone()).or_default();
+                if !excluded.contains(&party_id) {
+                    excluded.push(party_id);
+                    excluded.sort_unstable();
                 }
                 Ok(state)
             })?;

--- a/crates/sortition/src/sortition/actor.rs
+++ b/crates/sortition/src/sortition/actor.rs
@@ -19,10 +19,10 @@ use e3_data::{AutoPersist, Persistable, Repository};
 use e3_events::hlc::HlcTimestamp;
 use e3_events::{
     prelude::*, trap, CiphernodeAdded, CiphernodeRemoved, Committee, CommitteeFinalized,
-    CommitteeMemberExpelled, CommitteePublished, CommitteeRequested, ConfigurationUpdated,
-    E3Failed, E3RequestComplete, E3Requested, E3Stage, E3StageChanged, EType, EventContext,
-    EventType, InterfoldEvent, OperatorActivationChanged, PlaintextOutputPublished, Seed,
-    Sequenced, TicketBalanceUpdated, TypedEvent,
+    CommitteeMemberExcluded, CommitteeMemberExpelled, CommitteePublished, CommitteeRequested,
+    ConfigurationUpdated, E3Failed, E3RequestComplete, E3Requested, E3Stage, E3StageChanged, EType,
+    EventContext, EventType, InterfoldEvent, OperatorActivationChanged, PlaintextOutputPublished,
+    Seed, Sequenced, TicketBalanceUpdated, TypedEvent,
 };
 use e3_events::{BusHandle, E3id, InterfoldEventData};
 use e3_utils::{NotifySync, MAILBOX_LIMIT};
@@ -47,6 +47,8 @@ pub struct Sortition {
     /// committee was finalized (e.g. out-of-order live delivery or a reorg). Drained when the
     /// `CommitteeFinalized` event for the same E3 is processed so early expulsions are not lost.
     pending_expulsions: HashMap<E3id, Vec<(CommitteeMemberExpelled, EventContext<Sequenced>)>>,
+    /// Raw local exclusions that arrived before the matching finalized committee.
+    pending_exclusions: HashMap<E3id, Vec<(CommitteeMemberExcluded, EventContext<Sequenced>)>>,
     /// Committee seeds rebuilt from registry replay before effects are enabled.
     sortition_seeds: HashMap<E3id, Seed>,
     /// Live E3 requests that arrived before their delayed committee seed.
@@ -80,6 +82,7 @@ impl Sortition {
             ciphernode_selector: params.ciphernode_selector,
             address: params.address,
             pending_expulsions: HashMap::new(),
+            pending_exclusions: HashMap::new(),
             sortition_seeds: HashMap::new(),
             pending_requests: HashMap::new(),
         }
@@ -127,6 +130,7 @@ impl Sortition {
                 EventType::PlaintextOutputPublished,
                 EventType::CommitteeFinalized,
                 EventType::CommitteeMemberExpelled,
+                EventType::CommitteeMemberExcluded,
                 EventType::E3Failed,
                 EventType::E3StageChanged,
                 EventType::E3RequestComplete,
@@ -236,6 +240,43 @@ impl Sortition {
 
         self.bus.publish(
             CommitteeMemberExpelled {
+                party_id: Some(party_id),
+                ..data
+            },
+            ec,
+        )?;
+
+        Ok(true)
+    }
+
+    /// Resolve a locally excluded node against the immutable finalized committee roster.
+    fn try_resolve_and_publish_exclusion(
+        &self,
+        data: CommitteeMemberExcluded,
+        ec: EventContext<Sequenced>,
+    ) -> Result<bool> {
+        let node_addr = data.node.to_string();
+
+        let Some(committee) = self.get_committee(&data.e3_id) else {
+            return Ok(false);
+        };
+
+        let Some(party_id) = committee.party_id_for(&node_addr) else {
+            warn!(
+                "Locally excluded node {} not found in committee for e3_id={}",
+                node_addr, data.e3_id
+            );
+            return Ok(true);
+        };
+
+        info!(
+            node = %node_addr,
+            party_id,
+            e3_id = %data.e3_id,
+            "Resolved local E3 exclusion to a stable party ID"
+        );
+        self.bus.publish(
+            CommitteeMemberExcluded {
                 party_id: Some(party_id),
                 ..data
             },

--- a/crates/sortition/src/sortition/handlers/committee.rs
+++ b/crates/sortition/src/sortition/handlers/committee.rs
@@ -45,6 +45,55 @@ impl Handler<TypedEvent<CommitteeFinalized>> for Sortition {
                 }
             }
 
+            if let Some(buffered) = self.pending_exclusions.remove(&msg.e3_id) {
+                info!(
+                    e3_id = %msg.e3_id,
+                    count = buffered.len(),
+                    "Draining local exclusions received before committee finalization"
+                );
+                for (data, buffered_ec) in buffered {
+                    if let Err(error) = self.try_resolve_and_publish_exclusion(data, buffered_ec) {
+                        warn!(
+                            e3_id = %msg.e3_id,
+                            %error,
+                            "Failed to resolve a buffered local exclusion"
+                        );
+                    }
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+impl Handler<TypedEvent<CommitteeMemberExcluded>> for Sortition {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        msg: TypedEvent<CommitteeMemberExcluded>,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let (data, ec) = msg.into_components();
+        if data.party_id.is_some() {
+            return;
+        }
+
+        trap(EType::Sortition, &self.bus.with_ec(&ec), || {
+            if self.try_resolve_and_publish_exclusion(data.clone(), ec.clone())? {
+                return Ok(());
+            }
+
+            warn!(
+                node = %data.node,
+                e3_id = %data.e3_id,
+                "Local exclusion arrived before committee finalization; buffering it"
+            );
+            self.pending_exclusions
+                .entry(data.e3_id.clone())
+                .or_default()
+                .push((data, ec));
             Ok(())
         })
     }

--- a/crates/sortition/src/sortition/handlers/envelope.rs
+++ b/crates/sortition/src/sortition/handlers/envelope.rs
@@ -50,6 +50,9 @@ impl Handler<InterfoldEvent> for Sortition {
             InterfoldEventData::CommitteeMemberExpelled(data) => {
                 self.notify_sync(ctx, TypedEvent::new(data, ec))
             }
+            InterfoldEventData::CommitteeMemberExcluded(data) => {
+                self.notify_sync(ctx, TypedEvent::new(data, ec))
+            }
             InterfoldEventData::E3Failed(data) => self.notify_sync(ctx, TypedEvent::new(data, ec)),
             InterfoldEventData::E3StageChanged(data) => {
                 self.notify_sync(ctx, TypedEvent::new(data, ec))

--- a/crates/sortition/src/sortition/handlers/lifecycle.rs
+++ b/crates/sortition/src/sortition/handlers/lifecycle.rs
@@ -134,6 +134,7 @@ impl Handler<TypedEvent<E3RequestComplete>> for Sortition {
                     Ok(committees)
                 })?;
             self.pending_expulsions.remove(&msg.e3_id);
+            self.pending_exclusions.remove(&msg.e3_id);
             self.sortition_seeds.remove(&msg.e3_id);
             self.pending_requests.remove(&msg.e3_id);
             Ok(())

--- a/scripts/invariant-baselines.env
+++ b/scripts/invariant-baselines.env
@@ -4,4 +4,4 @@
 
 # Call sites of `.do_send(` in crates/**/*.rs — fire-and-forget sends, allowed only for
 # best-effort telemetry (agent/ARCHITECTURE.md §Routing, agent/INVARIANTS.md).
-DO_SEND_BASELINE=107
+DO_SEND_BASELINE=95


### PR DESCRIPTION
## Summary

- check the exact proof-type slash policy after an accusation quorum
- when the policy is disabled, persist an E3-scoped local exclusion so the runtime stops waiting for known-bad work
- keep the full finalized committee for proof binding while current-E3 collectors and aggregator failover skip the excluded member
- preserve the existing on-chain submission path for enabled proof policies and suppress disabled-policy retries after restart

This fallback does not slash or ban the operator, change future selection, or withhold on-chain rewards. Those effects still require an enabled slash policy.

## Testing

- `pnpm evm:build`
- `cargo test --lib`
- `cargo test --doc`
- `cargo fmt --all -- --check`
- `pnpm check:docs`
- `pnpm check:invariants`
