### PR TITLE
fix(contracts): price required decryption shares

### DIFF
--- a/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
+++ b/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
@@ -74,8 +74,8 @@ Requester calls: Interfold.request({
 │
 ├─ FEE CALCULATION:
 │   ├─ fee = getE3Quote()
-│   │   → InterfoldPricing uses the active circuit [T, N].
-│   │   → The quote uses T for decryption work and H for on-chain viability only.
+│   │   → InterfoldPricing validates the active circuit [T, H, N].
+│   │   → The quote uses N for committee-wide work and H for required decryption shares.
 │   │   → It also uses the time windows,
 │   │     proof counts, availability, decryption/publication costs, and margin
 │   │   → availability covers at least request time through input-window end

--- a/packages/interfold-contracts/contracts/lib/InterfoldPricing.sol
+++ b/packages/interfold-contracts/contracts/lib/InterfoldPricing.sol
@@ -349,7 +349,7 @@ library InterfoldPricing {
 
         ActiveCryptoConfig.validateCommittee(committeeSize, threshold);
         uint256 n = ActiveCryptoConfig.N;
-        uint256 m = ActiveCryptoConfig.T;
+        uint256 h = uint256(threshold[0]);
 
         uint256 duration = _billableDuration(
             pc,
@@ -360,7 +360,7 @@ library InterfoldPricing {
             inputWindowEnd
         );
 
-        uint256 baseFee = _baseFee(pc, n, m, duration);
+        uint256 baseFee = _baseFee(pc, n, h, duration);
 
         // Apply margin markup
         fee =
@@ -384,7 +384,7 @@ library InterfoldPricing {
     function _baseFee(
         IInterfold.PricingConfig calldata pc,
         uint256 n,
-        uint256 m,
+        uint256 h,
         uint256 duration
     ) private pure returns (uint256 baseFee) {
         // ZK proof count per node: 14 fixed + 4 × (N-1) scaling.
@@ -405,11 +405,11 @@ library InterfoldPricing {
         // Availability cost (linear in n × duration)
         baseFee += pc.availabilityPerNodePerSec * n * duration;
 
-        // Decryption cost (linear in m)
-        baseFee += pc.decryptionPerNode * m;
-        // Decryption coordination cost (quadratic in m)
-        if (m > 1) {
-            baseFee += (pc.coordinationPerPair * (m * (m - 1))) / 2;
+        // Decryption cost (linear in the required H shares)
+        baseFee += pc.decryptionPerNode * h;
+        // Decryption coordination cost (quadratic in H)
+        if (h > 1) {
+            baseFee += (pc.coordinationPerPair * (h * (h - 1))) / 2;
         }
 
         // Publication base cost

--- a/packages/interfold-contracts/test/Pricing/Pricing.spec.ts
+++ b/packages/interfold-contracts/test/Pricing/Pricing.spec.ts
@@ -108,9 +108,9 @@ describe("E3 Pricing", function () {
       const { interfold, request, ciphernodeRegistryContract } =
         await loadFixture(setup);
 
-      // Minimum uses circuit threshold T=1 and committee size N=3.
+      // Minimum requires H=2 decryption shares from an N=3 committee.
       const n = 3n; // total committee
-      const m = 1n; // quorum
+      const h = 2n; // required decryption shares
 
       // Get pricing config
       const pc = await interfold.getPricingConfig();
@@ -138,8 +138,8 @@ describe("E3 Pricing", function () {
       if (n > 1n) baseFee += (pc.coordinationPerPair * n * (n - 1n)) / 2n;
       baseFee += pc.verificationPerProof * n * proofsPerNode;
       baseFee += pc.availabilityPerNodePerSec * n * duration;
-      baseFee += pc.decryptionPerNode * m;
-      if (m > 1n) baseFee += (pc.coordinationPerPair * m * (m - 1n)) / 2n;
+      baseFee += pc.decryptionPerNode * h;
+      if (h > 1n) baseFee += (pc.coordinationPerPair * h * (h - 1n)) / 2n;
       baseFee += pc.publicationBase;
 
       const marginBps = pc.marginBps;
@@ -147,6 +147,29 @@ describe("E3 Pricing", function () {
 
       const actualFee = await interfold.getE3Quote(request);
       expect(actualFee).to.equal(expectedFee);
+    });
+
+    it("charges each required decryption share", async function () {
+      const { interfold, request } = await loadFixture(setup);
+      const decryptionPerNode = 300000n;
+
+      await setPricingConfig(interfold, {
+        ...defaultPricingConfig,
+        decryptionPerNode: 0n,
+        marginBps: 0,
+      });
+      const feeWithoutDecryption = await interfold.getE3Quote(request);
+
+      await setPricingConfig(interfold, {
+        ...defaultPricingConfig,
+        decryptionPerNode,
+        marginBps: 0,
+      });
+      const feeWithDecryption = await interfold.getE3Quote(request);
+
+      expect(feeWithDecryption - feeWithoutDecryption).to.equal(
+        decryptionPerNode * 2n,
+      );
     });
 
     it("fee increases with longer input window", async function () {
@@ -692,15 +715,15 @@ describe("E3 Pricing", function () {
       // Compute the expected fee using the new duration.
       const pc2 = await interfold.getPricingConfig();
       const n = 3n;
-      const m = 1n;
+      const h = 2n;
       const proofsPerNode = 14n + 4n * (n - 1n);
       let baseFee = pc2.keyGenFixedPerNode * n;
       baseFee += pc2.keyGenPerEncryptionProof * n * proofsPerNode;
       if (n > 1n) baseFee += (pc2.coordinationPerPair * n * (n - 1n)) / 2n;
       baseFee += pc2.verificationPerProof * n * proofsPerNode;
       baseFee += pc2.availabilityPerNodePerSec * n * newDuration;
-      baseFee += pc2.decryptionPerNode * m;
-      if (m > 1n) baseFee += (pc2.coordinationPerPair * m * (m - 1n)) / 2n;
+      baseFee += pc2.decryptionPerNode * h;
+      if (h > 1n) baseFee += (pc2.coordinationPerPair * h * (h - 1n)) / 2n;
       baseFee += pc2.publicationBase;
       const expectedFee = (baseFee * (10000n + BigInt(pc2.marginBps))) / 10000n;
 
@@ -715,8 +738,8 @@ describe("E3 Pricing", function () {
       if (n > 1n) oldBaseFee += (pc2.coordinationPerPair * n * (n - 1n)) / 2n;
       oldBaseFee += pc2.verificationPerProof * n * proofsPerNode;
       oldBaseFee += pc2.availabilityPerNodePerSec * n * oldDuration;
-      oldBaseFee += pc2.decryptionPerNode * m;
-      if (m > 1n) oldBaseFee += (pc2.coordinationPerPair * m * (m - 1n)) / 2n;
+      oldBaseFee += pc2.decryptionPerNode * h;
+      if (h > 1n) oldBaseFee += (pc2.coordinationPerPair * h * (h - 1n)) / 2n;
       oldBaseFee += pc2.publicationBase;
       const oldFee = (oldBaseFee * (10000n + BigInt(pc2.marginBps))) / 10000n;
 


### PR DESCRIPTION
## Summary

- calculate decryption pricing from H, the required share count, instead of T
- keep the quote formula and lifecycle documentation aligned
- add focused coverage for the H-based charge

## Tests

- pnpm --filter @interfold/contracts test test/Pricing/Pricing.spec.ts
- pnpm evm:test
- pnpm lint
- pnpm check:docs
- pnpm check:invariants
- pnpm check:committee
- pnpm --filter @interfold/contracts size:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated fee quotes to calculate decryption costs using the active required-share threshold.
  * Improved circuit validation for fee calculations.
  * Ensured each required decryption share is included in pricing.
  * Updated fee-calculation and duration-precision results for more accurate quotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->