### PR TITLE
fix(contracts): remove CRISP deployment cycle

### DIFF
--- a/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
+++ b/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
@@ -36,6 +36,10 @@ Interfold starts with requests paused. Deployment wires and validates one comple
 generation before it enables requests. Governance must pause requests and drain the current
 generation before it replaces a registry, bonding registry, slashing manager, or refund manager.
 
+An E3 Program can deploy before its Interfold controller. Interfold must register the deployed
+program before the program owner binds that controller one time. This order removes the constructor
+dependency between Interfold and applications such as CRISP.
+
 ---
 
 ## Step 1: E3 Request (On-Chain)

--- a/agent/flow-trace/05_FAILURE_REFUND_SLASHING.md
+++ b/agent/flow-trace/05_FAILURE_REFUND_SLASHING.md
@@ -185,8 +185,8 @@ Anyone calls: Interfold.processE3Failure(e3Id)
 │     │  │                                                       │
 │     │  │  2b. Requester liability: use request-time work BPS:  │
 │     │  │      KeyPublished / CiphertextReady defaults:         │
-│     │  │      honestNodeAmount = payment * 4000 / 10000        │
-│     │  │      requesterAmount = payment * 5500 / 10000         │
+│     │  │      honestNodeAmount = payment * 5000 / 10000        │
+│     │  │      requesterAmount = payment * 4500 / 10000         │
 │     │  │      protocolAmount = remaining 500 / 10000           │
 │     │  │      → if no honest recipient exists, fold the work   │
 │     │  │        share back into requesterAmount                │
@@ -283,15 +283,15 @@ Scenario: E3 fails at KeyPublished stage (compute timeout)
   Payment: 1,000,000 fee-token units (one token with 6 decimals)
   Honest nodes: 3 (out of 5 committee members, 2 were slashed)
 
-  Work completed:  40% → honestNodeAmount = 400,000
-  Work remaining:  55% → requesterAmount  = 550,000
+  Work completed:  50% → honestNodeAmount = 500,000
+  Work remaining:  45% → requesterAmount  = 450,000
   Protocol fee:     5% → protocolAmount   =  50,000
 
-  Each honest node claims: 400,000 / 3 = 133,333
-  The 1-unit division dust is credited to the treasury pull ledger
+  Each honest node claims: 500,000 / 3 = 166,666
+  The 2-unit division dust is credited to the treasury pull ledger
 
-  Requester claims: 550,000
-  Treasury claims: 50,001
+  Requester claims: 450,000
+  Treasury claims: 50,002
 ```
 
 ### Refund Example: Ciphernode Fault

--- a/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
+++ b/examples/CRISP/packages/crisp-contracts/contracts/CRISPProgram.sol
@@ -17,6 +17,10 @@ import { IHonkVerifier } from "./interfaces/IHonkVerifier.sol";
 import { IVotesToken } from "./interfaces/IVotesToken.sol";
 import { IERC6372Clock } from "./interfaces/IERC6372Clock.sol";
 
+interface IInterfoldProgramRegistry {
+  function e3Programs(IE3Program e3Program) external view returns (bool);
+}
+
 contract CRISPProgram is IE3Program, Ownable, EIP712 {
   using InternalLazyIMT for LazyIMTData;
 
@@ -118,6 +122,9 @@ contract CRISPProgram is IE3Program, Ownable, EIP712 {
   error CallerNotAuthorized();
   error E3AlreadyInitialized();
   error InterfoldAddressZero();
+  error InterfoldAlreadyBound();
+  error InterfoldNotContract();
+  error ProgramNotRegistered();
   error Risc0VerifierAddressZero();
   error InvalidHonkVerifier();
   error EmptyInputData();
@@ -159,30 +166,45 @@ contract CRISPProgram is IE3Program, Ownable, EIP712 {
   error InvalidComputeContext();
 
   // Events
+  event InterfoldBound(address indexed interfold);
   event InputPublished(uint256 indexed e3Id, bytes encryptedVote, uint256 index);
 
-  /// @notice Initialize the contract, binding it to a specified RISC Zero verifier.
-  /// @param _interfold The interfold address
+  /// @notice Initialize the contract without an Interfold controller.
+  /// @dev The owner binds the controller after Interfold registers this program.
+  /// @param _initialOwner The account that can configure and bind this program.
   /// @param _risc0Verifier The RISC Zero verifier address
   /// @param _honkVerifier The honk verifier address
   /// @param _imageId The image ID for the guest program
   constructor(
-    IInterfold _interfold,
+    address _initialOwner,
     IRiscZeroVerifier _risc0Verifier,
     IHonkVerifier _honkVerifier,
     IHonkVerifier _onchainHonkVerifier,
     bytes32 _imageId
-  ) Ownable(msg.sender) EIP712("CRISP", "1") {
-    if (address(_interfold) == address(0)) revert InterfoldAddressZero();
+  ) Ownable(_initialOwner) EIP712("CRISP", "1") {
     if (address(_risc0Verifier) == address(0)) revert Risc0VerifierAddressZero();
     if (address(_honkVerifier) == address(0)) revert InvalidHonkVerifier();
     if (address(_onchainHonkVerifier) == address(0)) revert InvalidHonkVerifier();
 
-    interfold = _interfold;
     risc0Verifier = _risc0Verifier;
     honkVerifier = _honkVerifier;
     onchainHonkVerifier = _onchainHonkVerifier;
     imageId = _imageId;
+  }
+
+  /// @notice Bind this program to its permanent Interfold controller.
+  /// @dev Interfold must register this program before the owner calls this function.
+  /// @param _interfold The Interfold controller that registered this program.
+  function bindInterfold(IInterfold _interfold) external onlyOwner {
+    if (address(interfold) != address(0)) revert InterfoldAlreadyBound();
+    if (address(_interfold) == address(0)) revert InterfoldAddressZero();
+    if (address(_interfold).code.length == 0) revert InterfoldNotContract();
+    if (!IInterfoldProgramRegistry(address(_interfold)).e3Programs(IE3Program(address(this)))) {
+      revert ProgramNotRegistered();
+    }
+
+    interfold = _interfold;
+    emit InterfoldBound(address(_interfold));
   }
 
   /// @notice The digest a voter signs to authorise one ballot.

--- a/examples/CRISP/packages/crisp-contracts/contracts/Mocks/MockInterfold.sol
+++ b/examples/CRISP/packages/crisp-contracts/contracts/Mocks/MockInterfold.sol
@@ -19,6 +19,11 @@ contract MockInterfold {
   uint256 public nextE3Id;
 
   mapping(uint256 => E3) public e3s;
+  mapping(IE3Program => bool) public e3Programs;
+
+  function registerE3Program(IE3Program program) external {
+    e3Programs[program] = true;
+  }
 
   function request(address program) external {
     _request(program, 2);

--- a/examples/CRISP/packages/crisp-contracts/deploy/crisp.ts
+++ b/examples/CRISP/packages/crisp-contracts/deploy/crisp.ts
@@ -118,7 +118,7 @@ export const deployCRISPContracts = async () => {
     owner,
   )
 
-  const crisp = await crispFactory.deploy(interfoldAddress, verifier, honkVerifierAddress, onchainHonkVerifierAddress, IMAGE_ID)
+  const crisp = await crispFactory.deploy(await owner.getAddress(), verifier, honkVerifierAddress, onchainHonkVerifierAddress, IMAGE_ID)
   await crisp.waitForDeployment()
 
   const crispAddress = await crisp.getAddress()
@@ -127,7 +127,7 @@ export const deployCRISPContracts = async () => {
       address: crispAddress,
       blockNumber: await ethers.provider.getBlockNumber(),
       constructorArgs: {
-        interfold: interfoldAddress,
+        initialOwner: await owner.getAddress(),
         verifierAddress: verifier,
         honkVerifierAddress,
         onchainHonkVerifierAddress,
@@ -138,9 +138,10 @@ export const deployCRISPContracts = async () => {
     chain,
   )
 
-  // enable the program on Interfold
+  // Register the program before its permanent Interfold binding.
   const tx = await interfold.registerE3Program(crispAddress)
   await tx.wait()
+  await (await crisp.bindInterfold(interfoldAddress)).wait()
 
   let tokenAddress
   if (useMocks) {

--- a/examples/CRISP/packages/crisp-contracts/tests/interfold-binding.test.ts
+++ b/examples/CRISP/packages/crisp-contracts/tests/interfold-binding.test.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+import { expect } from 'chai'
+import { deployCRISPProgram, deployMockInterfold, ethers } from './utils'
+
+describe('CRISP Interfold binding', function () {
+  it('binds once to the Interfold controller that registered the program', async function () {
+    const [owner, other] = await ethers.getSigners()
+    const mockInterfold = await deployMockInterfold()
+    const program = await deployCRISPProgram({ mockInterfold, bindInterfold: false })
+    const programAddress = await program.getAddress()
+    const interfoldAddress = await mockInterfold.getAddress()
+
+    expect(await program.owner()).to.equal(await owner.getAddress())
+    expect(await program.interfold()).to.equal(ethers.ZeroAddress)
+
+    await expect(program.connect(other).bindInterfold(interfoldAddress))
+      .to.be.revertedWithCustomError(program, 'OwnableUnauthorizedAccount')
+      .withArgs(await other.getAddress())
+    await expect(program.bindInterfold(ethers.ZeroAddress)).to.be.revertedWithCustomError(program, 'InterfoldAddressZero')
+    await expect(program.bindInterfold(await owner.getAddress())).to.be.revertedWithCustomError(program, 'InterfoldNotContract')
+    await expect(program.bindInterfold(interfoldAddress)).to.be.revertedWithCustomError(program, 'ProgramNotRegistered')
+
+    await (await mockInterfold.registerE3Program(programAddress)).wait()
+    await expect(program.bindInterfold(interfoldAddress)).to.emit(program, 'InterfoldBound').withArgs(interfoldAddress)
+    expect(await program.interfold()).to.equal(interfoldAddress)
+
+    await expect(program.bindInterfold(interfoldAddress)).to.be.revertedWithCustomError(program, 'InterfoldAlreadyBound')
+  })
+})

--- a/examples/CRISP/packages/crisp-contracts/tests/utils.ts
+++ b/examples/CRISP/packages/crisp-contracts/tests/utils.ts
@@ -105,6 +105,7 @@ export async function deployCRISPProgram(
     onchainHonkVerifier?: HonkVerifier
     poseidonT3?: PoseidonT3
     risc0Verifier?: MockRISC0Verifier
+    bindInterfold?: boolean
   } = {},
 ) {
   const poseidonT3 = contracts.poseidonT3 || (await deployPoseidonT3())
@@ -121,9 +122,10 @@ export async function deployCRISPProgram(
       'npm/poseidon-solidity@0.0.5/PoseidonT3.sol:PoseidonT3': await poseidonT3.getAddress(),
     },
   })
+  const [owner] = await ethers.getSigners()
 
   const program = await programFactory.deploy(
-    await mockInterfold.getAddress(),
+    await owner.getAddress(),
     risc0Verifier,
     await honkVerifier.getAddress(),
     await onchainHonkVerifier.getAddress(),
@@ -131,6 +133,11 @@ export async function deployCRISPProgram(
   )
 
   await program.waitForDeployment()
+
+  if (contracts.bindInterfold !== false) {
+    await (await mockInterfold.registerE3Program(await program.getAddress())).wait()
+    await (await program.bindInterfold(await mockInterfold.getAddress())).wait()
+  }
 
   return program as unknown as CRISPProgram
 }

--- a/packages/interfold-contracts/contracts/E3RefundManager.sol
+++ b/packages/interfold-contracts/contracts/E3RefundManager.sol
@@ -198,8 +198,8 @@ contract E3RefundManager is IE3RefundManager, Ownable2StepUpgradeable {
 
         _workAllocation = WorkValueAllocation({
             committeeFormationBps: 1000,
-            dkgBps: 3000,
-            decryptionBps: 5500,
+            dkgBps: 4000,
+            decryptionBps: 4500,
             protocolBps: 500,
             successSlashedNodeBps: 5000
         });

--- a/packages/interfold-contracts/test/E3Lifecycle/E3Integration.spec.ts
+++ b/packages/interfold-contracts/test/E3Lifecycle/E3Integration.spec.ts
@@ -399,8 +399,8 @@ describe("E3 Integration - Refund/Timeout Mechanism", function () {
       const scenarios = [
         { stage: 1, requesterBps: 9500n, nodeBps: 0n },
         { stage: 2, requesterBps: 8500n, nodeBps: 1000n },
-        { stage: 3, requesterBps: 5500n, nodeBps: 4000n },
-        { stage: 4, requesterBps: 5500n, nodeBps: 4000n },
+        { stage: 3, requesterBps: 4500n, nodeBps: 5000n },
+        { stage: 4, requesterBps: 4500n, nodeBps: 5000n },
       ] as const;
 
       for (const scenario of scenarios) {
@@ -564,7 +564,11 @@ describe("E3 Integration - Refund/Timeout Mechanism", function () {
       expect(snapshot.bondingRegistry).to.equal(
         await bondingRegistry.getAddress(),
       );
-      expect(snapshot.allocation.committeeFormationBps).to.equal(1000);
+      expect(snapshot.allocation.committeeFormationBps).to.equal(1000n);
+      expect(snapshot.allocation.dkgBps).to.equal(4000n);
+      expect(snapshot.allocation.decryptionBps).to.equal(4500n);
+      expect(snapshot.allocation.protocolBps).to.equal(500n);
+      expect(snapshot.allocation.successSlashedNodeBps).to.equal(5000n);
 
       await e3RefundManager.connect(owner).setWorkAllocation({
         committeeFormationBps: 2000,
@@ -596,7 +600,7 @@ describe("E3 Integration - Refund/Timeout Mechanism", function () {
       const distribution =
         await e3RefundManager.getRefundDistribution(firstE3Id);
       expect(distribution.honestNodeAmount).to.equal(
-        (distribution.originalPayment * 4000n) / 10000n,
+        (distribution.originalPayment * 5000n) / 10000n,
       );
       expect(
         await e3RefundManager.pendingTreasuryClaim(
@@ -614,7 +618,7 @@ describe("E3 Integration - Refund/Timeout Mechanism", function () {
       const unchanged = await e3RefundManager.getE3PolicySnapshot(firstE3Id);
       expect(unchanged.version).to.equal(1);
       expect(unchanged.treasury).to.equal(originalTreasury);
-      expect(unchanged.allocation.committeeFormationBps).to.equal(1000);
+      expect(unchanged.allocation.committeeFormationBps).to.equal(1000n);
     });
 
     it("blocks dependency rotation until the active generation is drained", async function () {
@@ -2555,10 +2559,10 @@ describe("E3 Integration - Refund/Timeout Mechanism", function () {
       const distribution =
         await e3RefundManager.getRefundDistribution(firstE3Id);
       expect(distribution.requesterAmount).to.equal(
-        (distribution.originalPayment * 5500n) / 10000n,
+        (distribution.originalPayment * 4500n) / 10000n,
       );
       expect(distribution.honestNodeAmount).to.equal(
-        (distribution.originalPayment * 4000n) / 10000n,
+        (distribution.originalPayment * 5000n) / 10000n,
       );
       expect(distribution.protocolAmount).to.equal(
         distribution.originalPayment -


### PR DESCRIPTION
## Summary

- deploy CRISP without an Interfold constructor dependency and bind it once after registration
- allow the final CRISP owner to differ from the deployment wallet
- update failure and cancellation allocations to 10% committee formation, 40% DKG, 45% decryption, and 5% protocol
- keep successful-E3 slashed funds split 50/50 between nodes and treasury

## Testing

- `pnpm evm:test`
- `pnpm --filter @interfold/contracts size:check`
- CRISP binding, census-mode, and journal contract tests
- `pnpm check:docs`
- `pnpm check:committee`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a two-step setup process for connecting CRISP programs to their Interfold controller.
  - Programs can now be registered before binding, with owner authorization and validation checks.
  - Added events and safeguards to prevent invalid or repeated controller connections.

- **Bug Fixes**
  - Updated E3 work-value allocations to 40% for DKG and 45% for decryption.
  - Corrected lifecycle refunds to allocate 45% to requesters and 50% to honest nodes while preserving the 5% protocol fee.

- **Tests**
  - Added coverage for authorization, registration, validation, successful binding, emitted events, and rebinding prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->