### PR TITLE
chore: allow bonded votes to support velocker [skip-line-limit]

### DIFF
--- a/agent/INVARIANTS.md
+++ b/agent/INVARIANTS.md
@@ -51,30 +51,44 @@ skip-proof feature containment (`pnpm check:invariants`, baselines in
   value already latest — exact, because a lookup at the skipped timepoint resolves to the preceding
   entry — so the permissionless `resyncBondedCheckpoint` cannot be used to grow an owner's history
   by a checkpoint per block. — `BondingRegistry.sol`; `BondedCheckpoints.sol`; `flow-trace/02`
-- **Bonded voting power is additive to the token, never to its supply.** `BondedVotes.getPastVotes`
-  sums wallet voting power and bonded FOLD, but `getPastTotalSupply` passes through unchanged:
-  bonded FOLD was transferred, not burned, so it is already counted. Adding it again would inflate
-  every quorum denominator. Summed voting power must never exceed total supply. — `BondedVotes.sol`;
-  `flow-trace/02`
-- **Bonded history and the token must share a clock.** `BondedCheckpoints` keys by `block.timestamp`
-  to match `InterfoldToken`'s ERC-6372 `mode=timestamp`, and `BondedVotes` compares both clocks at
-  construction. Summing a timestamp-keyed history with a block-numbered one answers for two
+- **The numerator comes from the votes source; the denominator is always the token.**
+  `BondedVotes.getPastVotes` sums whatever `votesSource` attributes to the account and that
+  account's bonded FOLD, while `getPastTotalSupply` passes the **token's** supply through unchanged.
+  `votesSource` is either the token itself (wallet-held FOLD votes, the original behaviour) or an
+  escrow adapter (only locked FOLD votes, so holders must lock to participate while operators keep
+  weight by bonding). Reading the denominator off the escrow instead would omit the bonded half and
+  let participation exceed 100%. Summed voting power must never exceed total supply. —
+  `BondedVotes.sol`; `flow-trace/02`
+- **Locked and bonded FOLD cannot overlap.** Locking custodies the token in the escrow and bonding
+  custodies it in the registry, so no token can be in both and the two halves of the numerator can
+  never count the same unit twice. Both were transferred rather than burned, so both are still
+  inside the token's total supply — which is what makes the ratio sound in either configuration. —
+  `BondedVotes.sol`; `flow-trace/02`
+- **Every summed source must share the token's clock.** `BondedCheckpoints` keys by
+  `block.timestamp` to match `InterfoldToken`'s ERC-6372 `mode=timestamp`, and `BondedVotes`
+  compares the history's clock **and** a non-token votes source's clock against the token's at
+  construction. Summing a timestamp-keyed history with a block-numbered source answers for two
   unrelated points in time and is undetectable downstream. — `BondedVotes.sol`; `flow-trace/02`
-- **`BondedVotes` binds token, registry and history as one unit.** The constructor reads
-  `checkpoints.registry()` and requires that registry's `getCiphernodeBondToken()` to equal the
-  token it reads votes from. The clock check alone proves the history speaks the token's units, not
-  that it is _about_ that token: a history written by a registry custodying something else would add
-  unbacked weight, and no reader downstream could tell. Because the check calls the registry,
-  `BondedVotes` can only be constructed after the registry is configured —
-  `protocol/deployContracts` therefore deploys `BondedCheckpoints` only, and
-  `--action activate-voting` deploys `BondedVotes` once the governance batch has run. —
-  `BondedVotes.sol`; `protocol/activateVoting.ts`; `flow-trace/02`
-- **`BondedVotes.balanceOf` nets the registry down to its own surplus.** Bonding moves FOLD into the
-  registry while the adapter attributes it to the bond owner, so counting it at both addresses would
-  place the same tokens twice and push summed balances above total supply — the denominator every
-  holder-percentage view divides by. The registry's entry subtracts `totalCiphernodeBondLiability`,
-  saturating at zero. `getVotes` needs no such adjustment: the registry never delegates, so bonded
-  FOLD carries no wallet votes to double. — `BondedVotes.sol`; `flow-trace/02`
+- **`BondedVotes` binds token, votes source, registry and history as one unit.** The constructor
+  reads `checkpoints.registry()` and requires that registry's `getCiphernodeBondToken()` to equal
+  the token. A non-token votes source is bound the same way: `_bindVotesSource` resolves its
+  `escrow()` and requires that escrow's `token()` to equal the voting token, reverting
+  `VotesSourceMismatch` otherwise. The clock check alone proves a source speaks the token's units,
+  not that it is _about_ that token: a history written by a registry custodying something else, or
+  an escrow over a different asset, would mint weight the denominator does not back, and no reader
+  downstream could tell. Because the registry check calls the registry, `BondedVotes` can only be
+  constructed after the registry is configured — `protocol/deployContracts` therefore deploys
+  `BondedCheckpoints` only, and `--action activate-voting` deploys `BondedVotes` once the governance
+  batch has run. — `BondedVotes.sol`; `protocol/activateVoting.ts`; `flow-trace/02`
+- **`BondedVotes.balanceOf` attributes custodied FOLD to whoever it belongs to.** Bonding moves FOLD
+  into the registry and locking moves it into the escrow, while the adapter attributes each to the
+  account it belongs to, so counting it at the custodian's address as well would place the same
+  tokens twice and push summed balances above total supply — the denominator every holder-percentage
+  view divides by. The registry's entry subtracts `totalCiphernodeBondLiability`, saturating at
+  zero; locked FOLD is added per account via the escrow's `votingPowerForAccount`, which is
+  delegation-blind, rather than the adapter's own `balanceOf`, which counts lock NFTs rather than
+  tokens. `getVotes` needs no such adjustment: the registry never delegates, so bonded FOLD carries
+  no wallet votes to double. — `BondedVotes.sol`; `flow-trace/02`
 - **`setBondedCheckpoints` is one-shot per ciphernode bond token, and self-verifying.** It requires
   the checkpoint contract to name this registry **and** to accept a write from it, checked by
   syncing the zero address, whose bonded total is always zero. `registry()` alone is insufficient:

--- a/agent/INVARIANTS.md
+++ b/agent/INVARIANTS.md
@@ -59,11 +59,29 @@ skip-proof feature containment (`pnpm check:invariants`, baselines in
   weight by bonding). Reading the denominator off the escrow instead would omit the bonded half and
   let participation exceed 100%. Summed voting power must never exceed total supply. —
   `BondedVotes.sol`; `flow-trace/02`
-- **Locked and bonded FOLD cannot overlap.** Locking custodies the token in the escrow and bonding
-  custodies it in the registry, so no token can be in both and the two halves of the numerator can
-  never count the same unit twice. Both were transferred rather than burned, so both are still
-  inside the token's total supply — which is what makes the ratio sound in either configuration. —
-  `BondedVotes.sol`; `flow-trace/02`
+- **Escrowed and bonded FOLD cannot overlap; vesting-locked and bonded do, and must be netted.**
+  Escrowing custodies the token in the escrow and bonding custodies it in the registry, so no token
+  can be in both. Both were transferred rather than burned, so both are still inside the token's
+  total supply — which is what makes the ratio sound in either configuration. Under an escrow votes
+  source `BondedVotes` adds a third source, `InterfoldToken.lockedBalanceAt`, because vesting-locked
+  FOLD sits in the holder's own wallet and the transfer hook will not let it reach the escrow. That
+  source **does** overlap the bond: a bond satisfies a lock (`transferableBalanceOf` nets the two),
+  so bonded FOLD is reported by `lockedBalanceAt` and by the bonded history while existing once.
+  `_lockedVotes` therefore subtracts the bond from the locked balance, saturating at zero, making
+  the pair worth `max(bonded, locked)` — then caps the result at the account's wallet balance,
+  because slashing takes the bond without taking the lock and would otherwise leave the account
+  voting with FOLD the slash recipient now holds. The lock schedule is read **only** when the votes
+  source is an escrow: when the token votes for itself, locked FOLD is wallet FOLD the token has
+  already counted. — `BondedVotes.sol`; `InterfoldToken.sol`; `flow-trace/02`
+- **The lock schedule is present-state, not history.** `lockedBalanceAt` walks an account's
+  **current** locks and evaluates them against the timestamp given, so a lock created after a
+  governance snapshot appears in that snapshot's answer — unlike the bonded history, which is
+  checkpointed. Sound for vesting locks, which are minted or claimed rather than acquired at will;
+  it must not be treated as a general past balance. — `BondedVotes.sol`; `InterfoldToken.sol`
+- **An escrow votes source requires a token with a lock schedule.** `_bindVotesSource` staticcalls
+  `lockedBalanceAt` once at construction and reverts `LockedBalancesUnsupported` if it cannot
+  answer. Tolerating the failure at read time would return zero and disenfranchise exactly the
+  locked holders the third source exists to enfranchise. — `BondedVotes.sol`
 - **Every summed source must share the token's clock.** `BondedCheckpoints` keys by
   `block.timestamp` to match `InterfoldToken`'s ERC-6372 `mode=timestamp`, and `BondedVotes`
   compares the history's clock **and** a non-token votes source's clock against the token's at
@@ -85,10 +103,12 @@ skip-proof feature containment (`pnpm check:invariants`, baselines in
   account it belongs to, so counting it at the custodian's address as well would place the same
   tokens twice and push summed balances above total supply — the denominator every holder-percentage
   view divides by. The registry's entry subtracts `totalCiphernodeBondLiability`, saturating at
-  zero; locked FOLD is added per account via the escrow's `votingPowerForAccount`, which is
-  delegation-blind, rather than the adapter's own `balanceOf`, which counts lock NFTs rather than
-  tokens. `getVotes` needs no such adjustment: the registry never delegates, so bonded FOLD carries
-  no wallet votes to double. — `BondedVotes.sol`; `flow-trace/02`
+  zero, and the escrow's own entry is netted to zero for the same reason — every unit it holds is
+  attributed to a locker, and it publishes no liability total to subtract instead; locked FOLD is
+  added per account via the escrow's `votingPowerForAccount`, which is delegation-blind, rather than
+  the adapter's own `balanceOf`, which counts lock NFTs rather than tokens. `getVotes` needs no such
+  adjustment: the registry never delegates, so bonded FOLD carries no wallet votes to double. —
+  `BondedVotes.sol`; `flow-trace/02`
 - **`setBondedCheckpoints` is one-shot per ciphernode bond token, and self-verifying.** It requires
   the checkpoint contract to name this registry **and** to accept a write from it, checked by
   syncing the zero address, whose bonded total is always zero. `registry()` alone is insufficient:

--- a/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
+++ b/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
@@ -453,9 +453,9 @@ quorum denominator while being unable to help meet it.
 
 Two contracts restore that weight:
 
-| Contract                     | Role                                                                               |
-| ---------------------------- | ---------------------------------------------------------------------------------- |
-| `registry/BondedCheckpoints` | Records `totalBonded(owner)` over time. Only `BondingRegistry` may write.          |
+| Contract                     | Role                                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------ |
+| `registry/BondedCheckpoints` | Records `totalBonded(owner)` over time. Only `BondingRegistry` may write.            |
 | `registry/BondedVotes`       | `IERC5805` view summing a primary vote source and bonded FOLD at the same timepoint. |
 
 ```text
@@ -463,8 +463,10 @@ BondedVotes.getPastVotes(account, t)              ← the NUMERATOR
 │
 ├─ votesSource.getPastVotes(account, t)           ← either the token or an escrow adapter
 │    ├─ votesSource == token   → wallet-held FOLD (needs delegation)
-│    └─ votesSource == escrow  → only locked FOLD; idle wallet FOLD carries no weight
-└─ BondedCheckpoints.getPastBonded(account, t)    ← FOLD bonded as an operator
+│    └─ votesSource == escrow  → only escrowed FOLD; idle wallet FOLD carries no weight
+├─ BondedCheckpoints.getPastBonded(account, t)    ← FOLD bonded as an operator
+└─ InterfoldToken.lockedBalanceAt(account, t)     ← vesting-locked FOLD, escrow source ONLY
+     minus the bonded total (saturating), because a bond satisfies a lock
 
 BondedVotes.getPastTotalSupply(t)                 ← the DENOMINATOR
 └─ InterfoldToken.getPastTotalSupply(t)           ← the TOKEN's supply, passed through unchanged
@@ -472,15 +474,50 @@ BondedVotes.getPastTotalSupply(t)                 ← the DENOMINATOR
 
 `votesSource` is fixed at construction. Passing the token itself gives the original behaviour:
 wallet-held FOLD votes through the token's own ERC20Votes delegation. Passing an escrow adapter
-means only FOLD locked in the escrow votes, so holders must lock to participate while operators
-keep their weight by bonding instead.
+means only FOLD locked in the escrow votes, so holders must lock to participate while operators keep
+their weight by bonding instead.
 
 Total supply is **not** adjusted, and is always read from the **token** rather than the votes
-source. Bonded and locked FOLD were both transferred, not burned, so both are already in the
-supply — adding either again would inflate every quorum denominator, which is the distortion this
-is meant to remove, and reading the escrow's supply instead would omit the bonded half entirely
-and let participation exceed 100%. Locked and bonded FOLD cannot overlap, because locking custodies
-the token in the escrow and bonding custodies it in the registry.
+source. Bonded and locked FOLD were both transferred, not burned, so both are already in the supply
+— adding either again would inflate every quorum denominator, which is the distortion this is meant
+to remove, and reading the escrow's supply instead would omit the bonded half entirely and let
+participation exceed 100%. Escrowed and bonded FOLD cannot overlap, because escrowing custodies the
+token in the escrow and bonding custodies it in the registry.
+
+### Vesting-locked FOLD
+
+Under an escrow votes source there is a third numerator: FOLD still encumbered by the token's own
+vesting locks. That FOLD sits in the holder's own wallet and `InterfoldToken._update` refuses to
+move it, so it can never be deposited into the escrow — without counting it, a locked holder would
+be barred from governance for the whole vesting schedule by a rule they cannot act on.
+
+Unlike the escrowed and bonded halves, this one **overlaps** the bond. A bond satisfies a lock:
+`transferableBalanceOf` lets a wallet move locked FOLD to the extent the bond already covers the
+obligation, so bonded FOLD is reported by both `lockedBalanceAt` and `getPastBonded` while existing
+exactly once. `_lockedVotes` subtracts the bonded total from the locked balance and saturates at
+zero, so the pair is worth `max(bonded, locked)` rather than their sum.
+
+The netting rests on the token's transfer rule, `balance >= locked - bonded`, enforced on every
+transfer. **Slashing breaks that rule**: it takes the bond without touching the lock, so an operator
+that had already moved locked FOLD out on the strength of the bond is left owing more than it holds,
+and the unbonded remainder would vote with FOLD the slash recipient now holds and can count too.
+`_lockedVotes` therefore caps the term at the account's wallet balance. The cap reads the present
+balance even for a past timepoint — a bound, never a source: it can only lower the term towards what
+the account demonstrably holds, and only that account's own power.
+
+Two limits worth holding on to:
+
+- The lock schedule is read **only** when the votes source is an escrow. When the token votes for
+  itself, locked FOLD is wallet FOLD its own checkpoints already carry, and adding it would double
+  every locked holder's weight.
+- `lockedBalanceAt` is not a checkpointed history — it walks the account's **current** locks and
+  evaluates them against the timestamp given. A lock created after a snapshot shows up in that
+  snapshot's answer. That is acceptable for vesting locks, which are minted or claimed rather than
+  acquired at will, but it is not a general past balance.
+
+The constructor staticcalls `lockedBalanceAt` once when binding an escrow votes source and reverts
+`LockedBalancesUnsupported` if the token cannot answer, rather than catching the failure at read
+time and silently returning zero for every locked holder.
 
 ### Checkpoint write sites
 
@@ -504,14 +541,14 @@ slashed. Voting power therefore stays with the owner for the duration of the exi
 ### Timepoints and configuration
 
 `BondedCheckpoints` keys history by `block.timestamp`, matching `InterfoldToken`'s ERC-6372
-`mode=timestamp` clock. `BondedVotes` compares the clocks at construction and reverts on a
-mismatch: summing a timestamp-keyed history with a block-numbered source would answer for two
-unrelated points in time, and nothing downstream could detect it. A votes source that is not the
-token is checked the same way.
+`mode=timestamp` clock. `BondedVotes` compares the clocks at construction and reverts on a mismatch:
+summing a timestamp-keyed history with a block-numbered source would answer for two unrelated points
+in time, and nothing downstream could detect it. A votes source that is not the token is checked the
+same way.
 
 The constructor also reads `checkpoints.registry()` and requires that registry to bond the same
-token it reads votes from. Matching clocks prove a source speaks the token's units, not that it
-is _about_ that token — a history written by a registry custodying something else would add unbacked
+token it reads votes from. Matching clocks prove a source speaks the token's units, not that it is
+_about_ that token — a history written by a registry custodying something else would add unbacked
 weight to every vote. A non-token votes source is bound by the same reasoning: `_bindVotesSource`
 resolves its `escrow()` and requires that escrow's `token()` to equal the voting token, reverting
 `VotesSourceMismatch` otherwise, because an escrow over a different asset would mint weight the
@@ -524,12 +561,15 @@ registry is configured: `protocol/deployContracts` deploys `BondedCheckpoints` o
 the governance app renders amounts from the metadata. There is no `transfer`, `transferFrom`,
 `approve` or `allowance`: the contract owns no position, so a spend attempt reverts on a missing
 selector. `balanceOf` subtracts `totalCiphernodeBondLiability` for the registry itself, because
-bonding moves FOLD into the registry while the adapter attributes it to the bond owner, and
-counting it at both addresses would put summed balances above total supply. When a votes source is
-configured, locked FOLD is added per account from the escrow's `votingPowerForAccount` for the same
-reason — it is custodied by the escrow but belongs to the locker. That function is used rather than
-the adapter's own `balanceOf`, which counts lock NFTs rather than tokens, and it is
-delegation-blind, matching what `balanceOf` means here.
+bonding moves FOLD into the registry while the adapter attributes it to the bond owner, and counting
+it at both addresses would put summed balances above total supply. When a votes source is
+configured, the escrow's own entry is netted to zero — every unit it custodies is already attributed
+to a locker, and unlike the registry it publishes no liability total to subtract, so FOLD donated to
+the escrow on its own account reads as nothing rather than risking a double count. Locked FOLD is
+added per account from the escrow's `votingPowerForAccount` for the same reason — it is custodied by
+the escrow but belongs to the locker. That function is used rather than the adapter's own
+`balanceOf`, which counts lock NFTs rather than tokens, and it is delegation-blind, matching what
+`balanceOf` means here.
 
 `setBondedCheckpoints` is settable **once per license token**, and verifies the candidate two ways
 before the slot is spent. It must name this registry, and it must accept a write from it, which the

--- a/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
+++ b/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
@@ -456,21 +456,31 @@ Two contracts restore that weight:
 | Contract                     | Role                                                                               |
 | ---------------------------- | ---------------------------------------------------------------------------------- |
 | `registry/BondedCheckpoints` | Records `totalBonded(owner)` over time. Only `BondingRegistry` may write.          |
-| `registry/BondedVotes`       | `IERC5805` view summing wallet voting power and bonded FOLD at the same timepoint. |
+| `registry/BondedVotes`       | `IERC5805` view summing a primary vote source and bonded FOLD at the same timepoint. |
 
 ```text
-BondedVotes.getPastVotes(account, t)
+BondedVotes.getPastVotes(account, t)              ← the NUMERATOR
 │
-├─ InterfoldToken.getPastVotes(account, t)        ← wallet voting power (needs delegation)
+├─ votesSource.getPastVotes(account, t)           ← either the token or an escrow adapter
+│    ├─ votesSource == token   → wallet-held FOLD (needs delegation)
+│    └─ votesSource == escrow  → only locked FOLD; idle wallet FOLD carries no weight
 └─ BondedCheckpoints.getPastBonded(account, t)    ← FOLD bonded as an operator
 
-BondedVotes.getPastTotalSupply(t)
-└─ InterfoldToken.getPastTotalSupply(t)           ← passed through unchanged
+BondedVotes.getPastTotalSupply(t)                 ← the DENOMINATOR
+└─ InterfoldToken.getPastTotalSupply(t)           ← the TOKEN's supply, passed through unchanged
 ```
 
-Total supply is **not** adjusted. Bonded FOLD was transferred, not burned, so it is already in the
-supply — adding it again would inflate every quorum denominator, which is the distortion this is
-meant to remove.
+`votesSource` is fixed at construction. Passing the token itself gives the original behaviour:
+wallet-held FOLD votes through the token's own ERC20Votes delegation. Passing an escrow adapter
+means only FOLD locked in the escrow votes, so holders must lock to participate while operators
+keep their weight by bonding instead.
+
+Total supply is **not** adjusted, and is always read from the **token** rather than the votes
+source. Bonded and locked FOLD were both transferred, not burned, so both are already in the
+supply — adding either again would inflate every quorum denominator, which is the distortion this
+is meant to remove, and reading the escrow's supply instead would omit the bonded half entirely
+and let participation exceed 100%. Locked and bonded FOLD cannot overlap, because locking custodies
+the token in the escrow and bonding custodies it in the registry.
 
 ### Checkpoint write sites
 
@@ -494,14 +504,18 @@ slashed. Voting power therefore stays with the owner for the duration of the exi
 ### Timepoints and configuration
 
 `BondedCheckpoints` keys history by `block.timestamp`, matching `InterfoldToken`'s ERC-6372
-`mode=timestamp` clock. `BondedVotes` compares the two clocks at construction and reverts on a
-mismatch: summing a timestamp-keyed history with a block-numbered one would answer for two unrelated
-points in time, and nothing downstream could detect it.
+`mode=timestamp` clock. `BondedVotes` compares the clocks at construction and reverts on a
+mismatch: summing a timestamp-keyed history with a block-numbered source would answer for two
+unrelated points in time, and nothing downstream could detect it. A votes source that is not the
+token is checked the same way.
 
 The constructor also reads `checkpoints.registry()` and requires that registry to bond the same
-token it reads votes from. Matching clocks prove the history speaks the token's units, not that it
+token it reads votes from. Matching clocks prove a source speaks the token's units, not that it
 is _about_ that token — a history written by a registry custodying something else would add unbacked
-weight to every vote. Because this calls the registry, `BondedVotes` cannot be built before the
+weight to every vote. A non-token votes source is bound by the same reasoning: `_bindVotesSource`
+resolves its `escrow()` and requires that escrow's `token()` to equal the voting token, reverting
+`VotesSourceMismatch` otherwise, because an escrow over a different asset would mint weight the
+denominator does not back. Because this calls the registry, `BondedVotes` cannot be built before the
 registry is configured: `protocol/deployContracts` deploys `BondedCheckpoints` only, and
 `--action activate-voting` deploys `BondedVotes` after the governance batch executes.
 
@@ -509,9 +523,13 @@ registry is configured: `protocol/deployContracts` deploys `BondedCheckpoints` o
 `name`, `symbol` — because Aragon's `TokenVotingSetup` gates installation on a `balanceOf` probe and
 the governance app renders amounts from the metadata. There is no `transfer`, `transferFrom`,
 `approve` or `allowance`: the contract owns no position, so a spend attempt reverts on a missing
-selector. `balanceOf` subtracts `totalLicenseLiability` for the registry itself, because bonding
-moves FOLD into the registry while the adapter attributes it to the bond owner, and counting it at
-both addresses would put summed balances above total supply.
+selector. `balanceOf` subtracts `totalCiphernodeBondLiability` for the registry itself, because
+bonding moves FOLD into the registry while the adapter attributes it to the bond owner, and
+counting it at both addresses would put summed balances above total supply. When a votes source is
+configured, locked FOLD is added per account from the escrow's `votingPowerForAccount` for the same
+reason — it is custodied by the escrow but belongs to the locker. That function is used rather than
+the adapter's own `balanceOf`, which counts lock NFTs rather than tokens, and it is
+delegation-blind, matching what `balanceOf` means here.
 
 `setBondedCheckpoints` is settable **once per license token**, and verifies the candidate two ways
 before the slot is spent. It must name this registry, and it must accept a write from it, which the

--- a/packages/interfold-contracts/contracts/interfaces/ILockAwareCiphernodeBondToken.sol
+++ b/packages/interfold-contracts/contracts/interfaces/ILockAwareCiphernodeBondToken.sol
@@ -8,4 +8,12 @@ pragma solidity 0.8.28;
 
 interface ILockAwareCiphernodeBondToken {
     function lockedBalanceOf(address account) external view returns (uint256);
+
+    /// @dev The same schedule as {lockedBalanceOf}, evaluated against an arbitrary timestamp
+    /// rather than the present. `BondedVotes` reads it so a governance snapshot counts the FOLD a
+    /// holder had encumbered at the snapshot, not what it has encumbered now.
+    function lockedBalanceAt(
+        address account,
+        uint64 timestamp
+    ) external view returns (uint256);
 }

--- a/packages/interfold-contracts/contracts/registry/BondedVotes.sol
+++ b/packages/interfold-contracts/contracts/registry/BondedVotes.sol
@@ -12,6 +12,12 @@ import {
 } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IBondedCheckpoints } from "../interfaces/IBondedCheckpoints.sol";
 import { IBondingRegistry } from "../interfaces/IBondingRegistry.sol";
+// FOLD's lock schedule, the same surface the bonding registry reads. Lock-encumbered FOLD sits in
+// the holder's own wallet and cannot be moved, so it can never be deposited into the escrow —
+// which is exactly why it needs counting here rather than being left to the escrow.
+import {
+    ILockAwareCiphernodeBondToken
+} from "../interfaces/ILockAwareCiphernodeBondToken.sol";
 
 /// @dev The slice of a voting-escrow IVotes adapter this contract needs to bind it to a token.
 /// Only consulted when the votes source is not the token itself.
@@ -60,8 +66,20 @@ interface IVotingEscrow {
  * never exceed the supply they are measured against. Reading the denominator off the escrow
  * instead would omit the bonded half entirely and let participation exceed 100%.
  *
- * Locked and bonded FOLD cannot overlap: locking custodies the token in the escrow and bonding
- * custodies it in the registry, so the same token can never be counted twice.
+ * A THIRD SOURCE, under an escrow votes source only: FOLD still encumbered by FOLD's own vesting
+ * locks. That FOLD sits in the holder's own wallet and {InterfoldToken._update} refuses to move
+ * it, so it can never reach the escrow — a locked holder would be disenfranchised for the whole
+ * lock schedule by a rule they cannot act on. {lockedBalanceAt} is read at the same timepoint as
+ * the other two and counted for them.
+ *
+ * Escrowed and bonded FOLD cannot overlap: the escrow and the registry custody the token at two
+ * different addresses, so the same token can never be at both. LOCKED AND BONDED DO OVERLAP, and
+ * that is the one place a naive sum would go wrong. A bond satisfies a lock — see
+ * {InterfoldToken.transferableBalanceOf}, which lets a wallet move its locked FOLD to the extent
+ * the bond already covers the obligation — so an account that bonds its locked FOLD reports the
+ * full amount under BOTH `lockedBalanceAt` and `getPastBonded` while holding it once. The locked
+ * half is therefore netted down by the bond: what remains is the part the wallet must still be
+ * holding, and `bonded + max(0, locked - bonded)` is just `max(bonded, locked)`.
  *
  * Delegation is deliberately not forwarded for the bonded part. `IVotes.delegate` here would have
  * to move a position the registry owns, which this contract cannot do. The primary source keeps
@@ -97,6 +115,10 @@ contract BondedVotes is IERC5805 {
 
     /// @notice Thrown when the history records bonds of a token other than the one read for votes.
     error TokenMismatch(address ciphernodeBondToken, address votingToken);
+
+    /// @notice Thrown when an escrow votes source is paired with a token that has no lock
+    /// schedule to read, which would silently disenfranchise every locked holder.
+    error LockedBalancesUnsupported(address votingToken);
 
     /// @notice Thrown for the delegation entry points, which this view cannot honour.
     error DelegationNotSupported();
@@ -183,6 +205,20 @@ contract BondedVotes is IERC5805 {
             revert VotesSourceMismatch(escrowToken, address(_token));
         }
 
+        // Probed once here rather than tolerated on every read. Under an escrow votes source the
+        // lock schedule is the ONLY way an encumbered holder can vote, so a token that cannot
+        // answer for it must not be deployed against silently: a `try/catch` at read time would
+        // return zero and disenfranchise exactly the holders this branch exists to enfranchise.
+        (bool ok, bytes memory result) = address(_token).staticcall(
+            abi.encodeCall(
+                ILockAwareCiphernodeBondToken.lockedBalanceAt,
+                (address(0), 0)
+            )
+        );
+        if (!ok || result.length != 32) {
+            revert LockedBalancesUnsupported(address(_token));
+        }
+
         return boundEscrow;
     }
 
@@ -203,15 +239,67 @@ contract BondedVotes is IERC5805 {
 
     /// @inheritdoc IVotes
     /// @dev The numerator: whatever the primary source attributes to the account, plus its bonded
-    /// FOLD. Both halves are FOLD-denominated and cannot overlap, since locking and bonding
-    /// custody the token in different places.
+    /// FOLD, plus — under an escrow votes source — the vesting-locked FOLD it cannot escrow. All
+    /// three are FOLD-denominated and read at the same timepoint.
+    ///
+    /// `getPastBonded` reverts on a timepoint that has not settled, and it is called before the
+    /// timepoint is narrowed to the clock's width, so the cast in {_lockedVotes} can only ever
+    /// see a timepoint the clock has already reached.
     function getPastVotes(
         address account,
         uint256 timepoint
     ) external view returns (uint256) {
+        uint256 bonded = checkpoints.getPastBonded(account, timepoint);
+
         return
             votesSource.getPastVotes(account, timepoint) +
-            checkpoints.getPastBonded(account, timepoint);
+            bonded +
+            _lockedVotes(account, uint64(timepoint), bonded);
+    }
+
+    /// @dev The vesting-locked half of the numerator, netted down by the bond.
+    ///
+    /// Zero unless the votes source is an escrow. When the token votes for itself, locked FOLD is
+    /// wallet FOLD and the token has already counted it — adding it again would simply double
+    /// every locked holder's weight.
+    ///
+    /// Netted, because a bond satisfies a lock: FOLD that is bonded is reported by BOTH
+    /// `lockedBalanceAt` and the bonded history while existing once, and `getPastVotes` already
+    /// counts the bonded side in full. What is left is the part of the obligation the wallet must
+    /// still be holding itself.
+    ///
+    /// UNLIKE the other two halves this is not a checkpointed history: `lockedBalanceAt` walks the
+    /// account's CURRENT locks and evaluates them against `timestamp`. A lock created after a
+    /// governance snapshot therefore shows up in that snapshot's answer. That is safe for the
+    /// vesting locks it exists for, which are minted or claimed rather than acquired at will, but
+    /// it is not a general-purpose past balance and must not be treated as one.
+    /// CAPPED at the wallet balance, because netting alone stops being enough once a bond can be
+    /// SLASHED. What makes `locked - bonded` a real holding is the token's own transfer rule,
+    /// `balance >= locked - bonded`, enforced on every transfer. Slashing cuts the bond without
+    /// cutting the lock, so an operator that had already moved locked FOLD out on the strength of
+    /// that bond is left owing more than it holds — and the uncapped term would vote with the
+    /// difference, FOLD that is now in the slash recipient's hands and countable there too.
+    ///
+    /// The cap reads the present balance even for a past timepoint. It is a bound, never a
+    /// source: it can only lower this term towards what the account demonstrably holds, and the
+    /// only power it can lower is the account's own. That is the right trade for a term already
+    /// evaluated from present-state locks.
+    /// @param bonded The account's bonded total at the same timepoint.
+    function _lockedVotes(
+        address account,
+        uint64 timestamp,
+        uint256 bonded
+    ) private view returns (uint256) {
+        if (escrow == address(0)) return 0;
+
+        uint256 locked = ILockAwareCiphernodeBondToken(address(token))
+            .lockedBalanceAt(account, timestamp);
+        if (locked <= bonded) return 0;
+
+        uint256 unbonded = locked - bonded;
+        uint256 held = IERC20Metadata(address(token)).balanceOf(account);
+
+        return unbonded > held ? held : unbonded;
     }
 
     /// @inheritdoc IVotes
@@ -227,12 +315,17 @@ contract BondedVotes is IERC5805 {
     }
 
     /// @inheritdoc IVotes
-    /// @dev Both halves read the present. Pairing a current wallet balance with
+    /// @dev Every half reads the present. Pairing a current wallet balance with
     /// `getPastBonded(account, clock() - 1)` would sum two different instants: a claim or a slash
     /// in this block would leave the bonded half stale and high, so the total could exceed what
     /// the owner holds — and, summed across owners, exceed total supply.
     function getVotes(address account) external view returns (uint256) {
-        return votesSource.getVotes(account) + checkpoints.bonded(account);
+        uint256 bonded = checkpoints.bonded(account);
+
+        return
+            votesSource.getVotes(account) +
+            bonded +
+            _lockedVotes(account, uint64(block.timestamp), bonded);
     }
 
     /// @inheritdoc IVotes
@@ -277,6 +370,18 @@ contract BondedVotes is IERC5805 {
                 .totalCiphernodeBondLiability();
             // Saturating: an accounting drift must not make the balance unreadable.
             held = held > custodied ? held - custodied : 0;
+        } else if (escrow != address(0) && account == escrow) {
+            // The escrow is netted for the same reason as the registry, and to the same end:
+            // every unit it holds is already attributed below to the account that locked it, so
+            // leaving it here too would place the same FOLD at two addresses and push summed
+            // balances past total supply.
+            //
+            // Netted to zero rather than by a liability figure, because the escrow exposes no
+            // such total, and inventing one from an interface this contract cannot verify would
+            // be the more dangerous guess. The cost is that FOLD donated to the escrow on its own
+            // account reads as nothing; the alternative cost is a double count, and only one of
+            // those breaks the denominator every holder-percentage view divides by.
+            held = 0;
         }
 
         // Locked FOLD is custodied by the escrow for the same reason bonded FOLD is custodied by

--- a/packages/interfold-contracts/contracts/registry/BondedVotes.sol
+++ b/packages/interfold-contracts/contracts/registry/BondedVotes.sol
@@ -7,6 +7,7 @@ pragma solidity 0.8.28;
 
 import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import { IERC5805 } from "@openzeppelin/contracts/interfaces/IERC5805.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {
     IERC20Metadata
 } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -242,9 +243,11 @@ contract BondedVotes is IERC5805 {
     /// FOLD, plus — under an escrow votes source — the vesting-locked FOLD it cannot escrow. All
     /// three are FOLD-denominated and read at the same timepoint.
     ///
-    /// `getPastBonded` reverts on a timepoint that has not settled, and it is called before the
-    /// timepoint is narrowed to the clock's width, so the cast in {_lockedVotes} can only ever
-    /// see a timepoint the clock has already reached.
+    /// Cast through `SafeCast` rather than directly. `getPastBonded` already reverts on a
+    /// timepoint that has not settled, which leaves nothing wide enough to truncate — but that
+    /// makes the narrowing safe only because of the order these two lines run in, and only for
+    /// the history this contract happens to be bound to. Reverting on the narrowing itself keeps
+    /// the guarantee local to this line, where a reader can check it.
     function getPastVotes(
         address account,
         uint256 timepoint
@@ -254,7 +257,7 @@ contract BondedVotes is IERC5805 {
         return
             votesSource.getPastVotes(account, timepoint) +
             bonded +
-            _lockedVotes(account, uint64(timepoint), bonded);
+            _lockedVotes(account, SafeCast.toUint64(timepoint), bonded);
     }
 
     /// @dev The vesting-locked half of the numerator, netted down by the bond.

--- a/packages/interfold-contracts/contracts/registry/BondedVotes.sol
+++ b/packages/interfold-contracts/contracts/registry/BondedVotes.sol
@@ -13,9 +13,25 @@ import {
 import { IBondedCheckpoints } from "../interfaces/IBondedCheckpoints.sol";
 import { IBondingRegistry } from "../interfaces/IBondingRegistry.sol";
 
+/// @dev The slice of a voting-escrow IVotes adapter this contract needs to bind it to a token.
+/// Only consulted when the votes source is not the token itself.
+interface IEscrowVotesSource {
+    function escrow() external view returns (address);
+}
+
+/// @dev The slice of a voting escrow this contract needs: what it custodies, and how much of it
+/// it attributes to an account irrespective of delegation.
+interface IVotingEscrow {
+    function token() external view returns (address);
+
+    function votingPowerForAccount(
+        address account
+    ) external view returns (uint256);
+}
+
 /**
  * @title BondedVotes
- * @notice Voting power that counts FOLD held in a wallet and FOLD bonded as an operator.
+ * @notice Voting power that counts FOLD bonded as an operator alongside a primary vote source.
  *
  * @dev Bonding transfers FOLD to `BondingRegistry`, which never delegates it. Under ERC20Votes an
  * undelegated balance carries no voting power, so those votes are not moved to the registry —
@@ -28,13 +44,41 @@ import { IBondingRegistry } from "../interfaces/IBondingRegistry.sol";
  * state and no privileges: it is a view over the token and the registry, so it can be deployed,
  * replaced or ignored without touching either.
  *
+ * TWO TOKEN REFERENCES, ON PURPOSE. `token` is FOLD: it supplies the metadata and, critically,
+ * the quorum DENOMINATOR. `votesSource` supplies the per-account NUMERATOR. They are separate
+ * because the two questions have different answers under a lock-to-vote model:
+ *
+ *   votesSource == token          wallet-held FOLD votes, via the token's own ERC20Votes
+ *                                 delegation. The original behaviour.
+ *   votesSource == an escrow      only FOLD locked in the escrow votes. Idle wallet FOLD carries
+ *                                 no weight, so holders must lock to participate — while
+ *                                 operators keep their weight by bonding instead.
+ *
+ * Keeping the denominator on FOLD in both cases is what makes the ratio sound. Every unit the
+ * numerator can produce — locked or bonded — is a FOLD that is still inside FOLD's total supply,
+ * because locking and bonding both TRANSFER the token rather than burn it. So summed votes can
+ * never exceed the supply they are measured against. Reading the denominator off the escrow
+ * instead would omit the bonded half entirely and let participation exceed 100%.
+ *
+ * Locked and bonded FOLD cannot overlap: locking custodies the token in the escrow and bonding
+ * custodies it in the registry, so the same token can never be counted twice.
+ *
  * Delegation is deliberately not forwarded for the bonded part. `IVotes.delegate` here would have
- * to move a position the registry owns, which this contract cannot do. Wallet-held FOLD keeps its
- * normal delegation through the token itself.
+ * to move a position the registry owns, which this contract cannot do. The primary source keeps
+ * its own delegation, whatever that means for it.
  */
 contract BondedVotes is IERC5805 {
-    /// @notice The FOLD token. Supplies wallet-held voting power and the total supply.
+    /// @notice The FOLD token. Supplies the metadata and the quorum denominator.
     IVotes public immutable token;
+
+    /// @notice Where per-account voting power is read from: the token itself, or an escrow
+    /// adapter when only locked FOLD may vote.
+    IVotes public immutable votesSource;
+
+    /// @notice The escrow behind `votesSource`, or zero when the votes source is the token.
+    /// @dev Held so {balanceOf} can attribute locked FOLD without going through the adapter's
+    /// own `balanceOf`, which counts lock NFTs rather than tokens.
+    address public immutable escrow;
 
     /// @notice Records bonded totals over time for the registry holding bonded FOLD.
     IBondedCheckpoints public immutable checkpoints;
@@ -48,6 +92,9 @@ contract BondedVotes is IERC5805 {
     /// @notice Thrown when the token and the history do not agree on what a timepoint means.
     error ClockMismatch(uint48 tokenClock, uint48 checkpointsClock);
 
+    /// @notice Thrown when the votes source measures a token other than the one being counted.
+    error VotesSourceMismatch(address escrowToken, address votingToken);
+
     /// @notice Thrown when the history records bonds of a token other than the one read for votes.
     error TokenMismatch(address ciphernodeBondToken, address votingToken);
 
@@ -55,11 +102,18 @@ contract BondedVotes is IERC5805 {
     error DelegationNotSupported();
 
     /**
-     * @param _token The FOLD token.
+     * @param _token The FOLD token: metadata, total supply, and the quorum denominator.
+     * @param _votesSource Where per-account voting power is read. Pass `_token` itself to count
+     * wallet-held FOLD, or an escrow IVotes adapter to count only locked FOLD.
      * @param _checkpoints The bonded-history contract.
      */
-    constructor(IVotes _token, IBondedCheckpoints _checkpoints) {
+    constructor(
+        IVotes _token,
+        IVotes _votesSource,
+        IBondedCheckpoints _checkpoints
+    ) {
         if (address(_token) == address(0)) revert ZeroAddress();
+        if (address(_votesSource) == address(0)) revert ZeroAddress();
         if (address(_checkpoints) == address(0)) revert ZeroAddress();
 
         // Checked once at deployment rather than on every read. Summing a timestamp-keyed history
@@ -91,8 +145,45 @@ contract BondedVotes is IERC5805 {
         }
 
         token = _token;
+        votesSource = _votesSource;
+        escrow = _bindVotesSource(_token, _votesSource, tokenClock);
         checkpoints = _checkpoints;
         registry = boundRegistry;
+    }
+
+    /// @dev Checks a votes source may be summed with this token's history, and resolves the
+    /// escrow behind it.
+    ///
+    /// Two conditions, for the same reason `TokenMismatch` exists on the other half of the
+    /// numerator. The clock, because a block-numbered source summed with a timestamp-keyed
+    /// history answers for two unrelated instants and nothing downstream could detect it. The
+    /// custodied token, because an escrow over something else would mint voting power this
+    /// token's supply does not back — the denominator would be FOLD while the numerator counted
+    /// something else, and participation could exceed 100% with nothing able to notice.
+    ///
+    /// A votes source that IS the token is trivially about itself, needs no escrow, and returns
+    /// zero here so {balanceOf} never consults one.
+    /// @return The escrow behind the votes source, or zero when it is the token itself.
+    function _bindVotesSource(
+        IVotes _token,
+        IVotes _votesSource,
+        uint48 tokenClock
+    ) private view returns (address) {
+        if (address(_votesSource) == address(_token)) return address(0);
+
+        uint48 votesClock = IERC5805(address(_votesSource)).clock();
+        if (tokenClock != votesClock) {
+            revert ClockMismatch(tokenClock, votesClock);
+        }
+
+        address boundEscrow = IEscrowVotesSource(address(_votesSource))
+            .escrow();
+        address escrowToken = IVotingEscrow(boundEscrow).token();
+        if (escrowToken != address(_token)) {
+            revert VotesSourceMismatch(escrowToken, address(_token));
+        }
+
+        return boundEscrow;
     }
 
     /// @notice Get the current timepoint, in ERC-6372 clock units.
@@ -111,20 +202,24 @@ contract BondedVotes is IERC5805 {
     }
 
     /// @inheritdoc IVotes
+    /// @dev The numerator: whatever the primary source attributes to the account, plus its bonded
+    /// FOLD. Both halves are FOLD-denominated and cannot overlap, since locking and bonding
+    /// custody the token in different places.
     function getPastVotes(
         address account,
         uint256 timepoint
     ) external view returns (uint256) {
         return
-            token.getPastVotes(account, timepoint) +
+            votesSource.getPastVotes(account, timepoint) +
             checkpoints.getPastBonded(account, timepoint);
     }
 
     /// @inheritdoc IVotes
-    /// @dev Passed through unchanged. Bonded FOLD is already counted in the token's supply — it
-    /// was transferred, not burned — so adding the bonded total again would double it and inflate
-    /// every quorum denominator. Leaving it alone is what makes bonded weight *fix* the quorum
-    /// distortion rather than compound it.
+    /// @dev The denominator, and always the TOKEN's supply — never the votes source's. Bonded and
+    /// locked FOLD are both already counted here: each was transferred, not burned. Adding either
+    /// total again would double it and inflate every quorum denominator, and reading the escrow's
+    /// supply instead would omit the bonded half and let participation exceed 100%. Leaving it
+    /// alone is what makes the ratio sound in both configurations.
     function getPastTotalSupply(
         uint256 timepoint
     ) external view returns (uint256) {
@@ -137,14 +232,14 @@ contract BondedVotes is IERC5805 {
     /// in this block would leave the bonded half stale and high, so the total could exceed what
     /// the owner holds — and, summed across owners, exceed total supply.
     function getVotes(address account) external view returns (uint256) {
-        return token.getVotes(account) + checkpoints.bonded(account);
+        return votesSource.getVotes(account) + checkpoints.bonded(account);
     }
 
     /// @inheritdoc IVotes
-    /// @dev The token's delegate. Bonded weight is not delegatable, so it always sits with the
-    /// bond owner regardless of what this returns.
+    /// @dev The primary source's delegate. Bonded weight is not delegatable, so it always sits
+    /// with the bond owner regardless of what this returns.
     function delegates(address account) external view returns (address) {
-        return token.delegates(account);
+        return votesSource.delegates(account);
     }
 
     ////////////////////////////////////////////////////////////
@@ -182,6 +277,15 @@ contract BondedVotes is IERC5805 {
                 .totalCiphernodeBondLiability();
             // Saturating: an accounting drift must not make the balance unreadable.
             held = held > custodied ? held - custodied : 0;
+        }
+
+        // Locked FOLD is custodied by the escrow for the same reason bonded FOLD is custodied by
+        // the registry, so it is attributed to the locker here rather than left sitting with the
+        // contract holding it. Read per-account and delegation-blind, matching what this function
+        // means; the adapter's own `balanceOf` is deliberately not used, because it counts lock
+        // NFTs rather than tokens.
+        if (escrow != address(0)) {
+            held += IVotingEscrow(escrow).votingPowerForAccount(account);
         }
 
         return held + checkpoints.bonded(account);

--- a/packages/interfold-contracts/contracts/test/MockBondedCheckpointsStub.sol
+++ b/packages/interfold-contracts/contracts/test/MockBondedCheckpointsStub.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+pragma solidity 0.8.28;
+
+/**
+ * @title MockBondedCheckpointsStub
+ * @notice A bonded history and its registry in one contract, for tests that only need
+ * `BondedVotes` to get PAST the history binding rather than to read any bond.
+ *
+ * @dev `BondedVotes` binds token, registry and history in its constructor: the history must share
+ * the token's clock, and the registry that wrote it must bond the same token. Satisfying that with
+ * the real contracts means a full system deployment plus a bonding-asset rotation, which is more
+ * than a test of a LATER constructor check needs. This answers `registry()` with itself and
+ * `getCiphernodeBondToken()` with whatever token the test is binding, so the checks pass and
+ * construction reaches the one being measured.
+ *
+ * Records no history: `bonded` and `getPastBonded` are zero. A test that needs bonded weight must
+ * use the real `BondedCheckpoints`.
+ */
+contract MockBondedCheckpointsStub {
+    address public immutable ciphernodeBondToken;
+
+    constructor(address _ciphernodeBondToken) {
+        ciphernodeBondToken = _ciphernodeBondToken;
+    }
+
+    /// @dev Itself, so one deployment serves as both halves of the binding.
+    function registry() external view returns (address) {
+        return address(this);
+    }
+
+    function getCiphernodeBondToken() external view returns (address) {
+        return ciphernodeBondToken;
+    }
+
+    /// @dev `mode=timestamp`, matching `InterfoldToken` and the real history.
+    function clock() external view returns (uint48) {
+        return uint48(block.timestamp);
+    }
+
+    function bonded(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastBonded(address, uint256) external pure returns (uint256) {
+        return 0;
+    }
+}

--- a/packages/interfold-contracts/contracts/test/MockEscrowVotes.sol
+++ b/packages/interfold-contracts/contracts/test/MockEscrowVotes.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+pragma solidity 0.8.28;
+
+/**
+ * @title MockVotingEscrow
+ * @notice The slice of a voting escrow `BondedVotes` reads: what it custodies, and how much of
+ * that it attributes to an account.
+ *
+ * @dev Stands in for the real escrow, whose voting-power curve is flat — locked FOLD produces
+ * exactly its own amount in voting power, with no decay and no boost. That is what makes escrow
+ * power addable to bonded FOLD at all, so the mock reproduces it by storing amounts directly.
+ */
+contract MockVotingEscrow {
+    address public token;
+    mapping(address account => uint256 amount) private _locked;
+
+    constructor(address _token) {
+        token = _token;
+    }
+
+    function setLocked(address account, uint256 amount) external {
+        _locked[account] = amount;
+    }
+
+    /// @dev Delegation-blind, matching the real escrow: it answers what the account itself locked.
+    function votingPowerForAccount(
+        address account
+    ) external view returns (uint256) {
+        return _locked[account];
+    }
+
+    /// @dev Lets a test point the escrow at a different token without redeploying the adapter,
+    /// to exercise the constructor's binding check.
+    function setToken(address _token) external {
+        token = _token;
+    }
+}
+
+/**
+ * @title MockEscrowVotesAdapter
+ * @notice An IVotes view over {MockVotingEscrow}, mirroring the real `EscrowIVotesAdapter`.
+ *
+ * @dev Deliberately NOT an ERC20: the real adapter has no `decimals`, `name`, `symbol` or
+ * `totalSupply`, and its `balanceOf` counts lock NFTs rather than tokens. `BondedVotes` must
+ * therefore never read metadata or supply through it — these tests exist to hold that line.
+ */
+contract MockEscrowVotesAdapter {
+    address public escrow;
+    uint48 private _clockOverride;
+    bool private _clockOverridden;
+
+    mapping(address account => uint256 power) private _votes;
+    mapping(address account => address delegatee) private _delegates;
+
+    constructor(address _escrow) {
+        escrow = _escrow;
+    }
+
+    function setVotes(address account, uint256 power) external {
+        _votes[account] = power;
+    }
+
+    function setDelegate(address account, address delegatee) external {
+        _delegates[account] = delegatee;
+    }
+
+    /// @dev Forces a clock the token cannot agree with, to exercise the mismatch guard.
+    function setClock(uint48 value) external {
+        _clockOverride = value;
+        _clockOverridden = true;
+    }
+
+    function clock() external view returns (uint48) {
+        if (_clockOverridden) return _clockOverride;
+        return uint48(block.timestamp);
+    }
+
+    // solhint-disable-next-line func-name-mixedcase
+    function CLOCK_MODE() external pure returns (string memory) {
+        return "mode=timestamp";
+    }
+
+    function getVotes(address account) external view returns (uint256) {
+        return _votes[account];
+    }
+
+    /// @dev Flat over time, like the escrow's curve: history is not what these tests measure.
+    function getPastVotes(
+        address account,
+        uint256
+    ) external view returns (uint256) {
+        return _votes[account];
+    }
+
+    function getPastTotalSupply(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function delegates(address account) external view returns (address) {
+        return _delegates[account];
+    }
+
+    function delegate(address) external pure {
+        revert("MockEscrowVotesAdapter: not supported");
+    }
+
+    function delegateBySig(
+        address,
+        uint256,
+        uint256,
+        uint8,
+        bytes32,
+        bytes32
+    ) external pure {
+        revert("MockEscrowVotesAdapter: not supported");
+    }
+}

--- a/packages/interfold-contracts/scripts/deployAndSave/bondedVotes.ts
+++ b/packages/interfold-contracts/scripts/deployAndSave/bondedVotes.ts
@@ -19,9 +19,15 @@ import {
  * The arguments for the deployAndSaveBondedVotes function
  */
 export interface BondedVotesArgs {
-  /** FOLD. Supplies wallet-held voting power and the total supply. */
+  /** FOLD. Supplies the metadata, the total supply and the quorum denominator. */
   token: string;
-  /** The bonded-history contract to read alongside the token. */
+  /**
+   * Where per-account voting power is read. Pass `token` to count wallet-held FOLD, or an escrow
+   * IVotes adapter to count only locked FOLD. Defaults to `token`, preserving the original
+   * behaviour for callers that predate the lock-to-vote model.
+   */
+  votesSource?: string;
+  /** The bonded-history contract to read alongside the votes source. */
   checkpoints: string;
   hre: HardhatRuntimeEnvironment;
 }
@@ -38,18 +44,21 @@ export interface BondedVotesArgs {
  */
 export const deployAndSaveBondedVotes = async ({
   token,
+  votesSource,
   checkpoints,
   hre,
 }: BondedVotesArgs): Promise<{ bondedVotes: BondedVotes }> => {
+  const resolvedVotesSource = votesSource ?? token;
   const { ethers } = await hre.network.connect();
   const [signer] = await ethers.getSigners();
   const chain = getDeploymentChain(hre);
 
   const preDeployedArgs = readDeploymentArgs("BondedVotes", chain);
-  // Both references are immutable, so a record for a different pair cannot be reused.
+  // All three references are immutable, so a record for a different triple cannot be reused.
   if (
     preDeployedArgs?.address &&
     preDeployedArgs?.constructorArgs?.token === token &&
+    preDeployedArgs?.constructorArgs?.votesSource === resolvedVotesSource &&
     preDeployedArgs?.constructorArgs?.checkpoints === checkpoints
   ) {
     return {
@@ -58,13 +67,21 @@ export const deployAndSaveBondedVotes = async ({
   }
 
   const factory = await ethers.getContractFactory("BondedVotes");
-  const bondedVotes = await factory.deploy(token, checkpoints);
+  const bondedVotes = await factory.deploy(
+    token,
+    resolvedVotesSource,
+    checkpoints,
+  );
   await bondedVotes.waitForDeployment();
 
   const address = await bondedVotes.getAddress();
   storeDeploymentArgs(
     {
-      constructorArgs: { token, checkpoints },
+      constructorArgs: {
+        token,
+        votesSource: resolvedVotesSource,
+        checkpoints,
+      },
       blockNumber: await ethers.provider.getBlockNumber(),
       address,
     },

--- a/packages/interfold-contracts/scripts/deploymentRecords.ts
+++ b/packages/interfold-contracts/scripts/deploymentRecords.ts
@@ -230,6 +230,7 @@ export function syncProtocolDeploymentRecords(
         blockNumber,
         constructorArgs: {
           token: config.fold,
+          votesSource: config.escrowVotesAdapter ?? config.fold,
           checkpoints: deployment.bondedCheckpoints,
         },
       },

--- a/packages/interfold-contracts/scripts/protocol/activateVoting.ts
+++ b/packages/interfold-contracts/scripts/protocol/activateVoting.ts
@@ -57,9 +57,14 @@ export async function actionActivateVoting(): Promise<void> {
     return;
   }
 
+  // Defaults to FOLD itself, which counts wallet-held votes. Setting `escrowVotesAdapter` makes
+  // locking a precondition for voting; the constructor checks the escrow custodies this same FOLD.
+  const votesSource = config.escrowVotesAdapter ?? config.fold;
+
   const factory = await ethers.getContractFactory("BondedVotes");
   const bondedVotes = await factory.deploy(
     config.fold,
+    votesSource,
     deployment.bondedCheckpoints,
   );
   await bondedVotes.waitForDeployment();
@@ -70,6 +75,9 @@ export async function actionActivateVoting(): Promise<void> {
 Bonded voting activated
   BondedCheckpoints: ${deployment.bondedCheckpoints}
   BondedVotes:       ${deployment.bondedVotes}
+  Votes source:      ${votesSource}${
+    config.escrowVotesAdapter ? " (locked FOLD only)" : " (wallet-held FOLD)"
+  }
 
 Point the governance plugin at BondedVotes as its voting token.
 `);

--- a/packages/interfold-contracts/scripts/protocol/types.ts
+++ b/packages/interfold-contracts/scripts/protocol/types.ts
@@ -38,6 +38,12 @@ export interface ProtocolConfigFile {
     proposalMetadata?: string;
   };
   fold: string;
+  /**
+   * Optional escrow IVotes adapter. When set, only FOLD locked in that escrow carries voting
+   * power and idle wallet FOLD carries none — operators keep their weight by bonding instead.
+   * Omit to count wallet-held FOLD, which is the original behaviour.
+   */
+  escrowVotesAdapter?: string;
   bondingRegistryProxy: string;
   bondingRegistryProxyAdmin: string;
   feeToken: string;

--- a/packages/interfold-contracts/scripts/protocol/validate.ts
+++ b/packages/interfold-contracts/scripts/protocol/validate.ts
@@ -238,6 +238,11 @@ export async function actionValidate(): Promise<void> {
     checks.push(
       ["bondedVotes.token", bondedVotes.token(), config.fold],
       [
+        "bondedVotes.votesSource",
+        bondedVotes.votesSource(),
+        config.escrowVotesAdapter ?? config.fold,
+      ],
+      [
         "bondedVotes.checkpoints",
         bondedVotes.checkpoints(),
         deployment.bondedCheckpoints,

--- a/packages/interfold-contracts/scripts/upgrade/safeProxyUpgrade.ts
+++ b/packages/interfold-contracts/scripts/upgrade/safeProxyUpgrade.ts
@@ -215,7 +215,11 @@ async function appendBondedVotingTxs(
   const bondedCheckpoints = await deployedAddress(checkpoints);
 
   const votesFactory = await ethers.getContractFactory("BondedVotes");
-  const votes = await votesFactory.deploy(config.fold, bondedCheckpoints);
+  const votes = await votesFactory.deploy(
+    config.fold,
+    config.escrowVotesAdapter ?? config.fold,
+    bondedCheckpoints,
+  );
   await votes.waitForDeployment();
   const bondedVotes = await deployedAddress(votes);
 

--- a/packages/interfold-contracts/test/Registry/BondedVotes.spec.ts
+++ b/packages/interfold-contracts/test/Registry/BondedVotes.spec.ts
@@ -1281,6 +1281,36 @@ describe("BondedVotes", function () {
       );
     });
 
+    /// The mirror of the registry netting. The escrow custodies real FOLD and every unit of it is
+    /// already attributed above to the account that locked it, so leaving it at the escrow's own
+    /// address as well would place the same tokens twice and push summed balances past total
+    /// supply — the denominator every holder-percentage view divides by.
+    it("nets the escrow down to nothing in balanceOf", async function () {
+      const { veBondedVotes, escrow, ciphernodeBondToken, otherHolderAddress } =
+        await loadFixture(veSetup);
+
+      const escrowAddress = await escrow.getAddress();
+      const custodied = ethers.parseEther("9000");
+
+      // Stands in for FOLD deposited by lockers: the escrow holds it, and it is attributed to the
+      // lockers rather than to the escrow.
+      await ciphernodeBondToken.mint(
+        escrowAddress,
+        custodied,
+        ethers.encodeBytes32String("Escrow deposits"),
+      );
+      await escrow.setLocked(otherHolderAddress, custodied);
+
+      expect(await ciphernodeBondToken.balanceOf(escrowAddress)).to.equal(
+        custodied,
+      );
+      expect(await veBondedVotes.balanceOf(escrowAddress)).to.equal(0n);
+      // Counted exactly once, at the locker.
+      expect(await veBondedVotes.balanceOf(otherHolderAddress)).to.equal(
+        (await ciphernodeBondToken.balanceOf(otherHolderAddress)) + custodied,
+      );
+    });
+
     it("routes delegation lookups to the votes source", async function () {
       const { veBondedVotes, adapter, bondOwnerAddress, otherHolderAddress } =
         await loadFixture(veSetup);
@@ -1332,6 +1362,333 @@ describe("BondedVotes", function () {
           await checkpoints.getAddress(),
         ]),
       ).to.be.revert(ethers);
+    });
+
+    /// FOLD's own vesting locks, the third source under an escrow votes source.
+    ///
+    /// Lock-encumbered FOLD sits in the holder's wallet and the token's transfer hook refuses to
+    /// move it, so it can never reach the escrow. Without counting it here a locked holder would
+    /// be barred from governance for the whole vesting schedule by a rule they cannot act on.
+    describe("vesting-locked FOLD", function () {
+      const ALLOCATION = ethers.parseEther("6000");
+
+      /// Tge-anchored, and the fixture never fires TGE, so the allocation stays fully locked for
+      /// every timestamp the tests read. What is being measured is the netting, not the curve.
+      async function allocate(
+        token: Awaited<ReturnType<typeof setup>>["ciphernodeBondToken"],
+        recipient: string,
+        amount: bigint,
+        policyName = "VE_LOCK",
+      ) {
+        const policyId = ethers.encodeBytes32String(policyName);
+        await token.createLockPolicy(policyId, {
+          holdUntil: 0n,
+          unlock: {
+            anchor: 1,
+            start: 0n,
+            cliffDuration: 0n,
+            vestDuration: 2n * 365n * 24n * 60n * 60n,
+          },
+        });
+        await token.mintAllocations([
+          {
+            recipient,
+            amount,
+            policyId,
+            label: ethers.encodeBytes32String("ve-test"),
+          },
+        ]);
+        return policyId;
+      }
+
+      it("counts locked FOLD for a holder who escrowed and bonded nothing", async function () {
+        const { veBondedVotes, ciphernodeBondToken, otherHolderAddress } =
+          await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, otherHolderAddress, ALLOCATION);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await ciphernodeBondToken.lockedBalanceOf(otherHolderAddress),
+        ).to.equal(ALLOCATION);
+        expect(
+          await veBondedVotes.getPastVotes(otherHolderAddress, timepoint),
+        ).to.equal(ALLOCATION);
+        expect(await veBondedVotes.getVotes(otherHolderAddress)).to.equal(
+          ALLOCATION,
+        );
+      });
+
+      it("adds locked FOLD to escrowed and bonded FOLD", async function () {
+        const {
+          veBondedVotes,
+          ciphernodeBondToken,
+          adapter,
+          bond,
+          bondOwnerAddress,
+        } = await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, bondOwnerAddress, ALLOCATION);
+        await adapter.setVotes(bondOwnerAddress, LOCKED);
+        await bond(BOND);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        // The bond is smaller than the lock, so it covers only part of the obligation: the rest
+        // is FOLD the wallet is still holding and still cannot escrow.
+        expect(
+          await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+        ).to.equal(LOCKED + ALLOCATION);
+      });
+
+      /// The one place a naive `locked + escrowed + bonded` sum goes wrong. A bond SATISFIES a
+      /// lock — {InterfoldToken.transferableBalanceOf} nets the bond against the obligation — so
+      /// bonded FOLD is reported by both `lockedBalanceAt` and the bonded history while existing
+      /// exactly once. Summing both would let an operator vote twice with the same token.
+      it("does not count FOLD twice when the bond covers the lock", async function () {
+        const { veBondedVotes, ciphernodeBondToken, bond, bondOwnerAddress } =
+          await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, bondOwnerAddress, BOND);
+        await bond(BOND);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await ciphernodeBondToken.lockedBalanceOf(bondOwnerAddress),
+        ).to.equal(BOND);
+        expect(
+          await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+        ).to.equal(BOND);
+      });
+
+      it("counts a bond larger than the lock exactly once", async function () {
+        const { veBondedVotes, ciphernodeBondToken, bond, bondOwnerAddress } =
+          await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, bondOwnerAddress, BOND / 4n);
+        await bond(BOND);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+        ).to.equal(BOND);
+      });
+
+      /// Soundness: what one account votes with never exceeds the supply it is measured against,
+      /// which is what any double count would break first.
+      it("keeps a locked, escrowed and bonded holder inside total supply", async function () {
+        const {
+          veBondedVotes,
+          ciphernodeBondToken,
+          adapter,
+          bond,
+          bondOwnerAddress,
+        } = await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, bondOwnerAddress, ALLOCATION);
+        await adapter.setVotes(bondOwnerAddress, LOCKED);
+        await bond(BOND);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+        ).to.be.lessThanOrEqual(
+          await veBondedVotes.getPastTotalSupply(timepoint),
+        );
+      });
+
+      /// Under an escrow votes source the lock schedule is the ONLY way an encumbered holder can
+      /// vote, so a token that cannot answer for it must be rejected at construction. Tolerating
+      /// the failure at read time would return zero and disenfranchise exactly the holders the
+      /// third source exists to enfranchise — silently, and for the whole vesting schedule.
+      it("refuses an escrow votes source over a token with no lock schedule", async function () {
+        const { veBondedVotes, foldAddress } = await loadFixture(veSetup);
+
+        // Carries the voting surface and a matching clock, but no `lockedBalanceAt`.
+        const lockless = await ethers.deployContract("MockVotesToken");
+        const locklessAddress = await lockless.getAddress();
+
+        const escrowOver = async (tokenAddress: string) => {
+          const escrow = await ethers.deployContract("MockVotingEscrow", [
+            tokenAddress,
+          ]);
+          return ethers.deployContract("MockEscrowVotesAdapter", [
+            await escrow.getAddress(),
+          ]);
+        };
+
+        await expect(
+          ethers.deployContract("BondedVotes", [
+            locklessAddress,
+            await (await escrowOver(locklessAddress)).getAddress(),
+            await (
+              await ethers.deployContract("MockBondedCheckpointsStub", [
+                locklessAddress,
+              ])
+            ).getAddress(),
+          ]),
+        ).to.be.revertedWithCustomError(
+          veBondedVotes,
+          "LockedBalancesUnsupported",
+        );
+
+        // Control: the same wiring over FOLD, which does answer, constructs. Without this the
+        // test would pass just as well if the stub were what rejected the deployment.
+        await expect(
+          ethers.deployContract("BondedVotes", [
+            foldAddress,
+            await (await escrowOver(foldAddress)).getAddress(),
+            await (
+              await ethers.deployContract("MockBondedCheckpointsStub", [
+                foldAddress,
+              ])
+            ).getAddress(),
+          ]),
+        ).to.not.be.revert(ethers);
+      });
+
+      /// The token votes for itself here, so the lock schedule is never read and a token without
+      /// one stays deployable. Probing unconditionally would break every such configuration for a
+      /// surface it does not use.
+      it("does not require a lock schedule when the token votes for itself", async function () {
+        const lockless = await ethers.deployContract("MockVotesToken");
+        const locklessAddress = await lockless.getAddress();
+
+        await expect(
+          ethers.deployContract("BondedVotes", [
+            locklessAddress,
+            locklessAddress,
+            await (
+              await ethers.deployContract("MockBondedCheckpointsStub", [
+                locklessAddress,
+              ])
+            ).getAddress(),
+          ]),
+        ).to.not.be.revert(ethers);
+      });
+
+      /// Netting the bond off the lock is only sound while the token's own transfer rule holds:
+      /// `balance >= locked - bonded`, checked on every transfer. SLASHING breaks it — it takes
+      /// the bond without touching the lock — so an operator that had already moved locked FOLD
+      /// out on the strength of that bond is left owing more than it holds. Uncapped, the locked
+      /// term would vote with FOLD that is now in the slash recipient's hands and countable
+      /// there too.
+      it("stops counting locked FOLD a slash left unbacked", async function () {
+        const { veBondedVotes, bondingRegistry, ciphernodeBondToken } =
+          await loadFixture(veSetup);
+
+        const [, , , , , locker, lockerOperator, sink] =
+          await ethers.getSigners();
+        const lockerAddress = await locker.getAddress();
+        const lockerOperatorAddress = await lockerOperator.getAddress();
+        const sinkAddress = await sink.getAddress();
+        const registryAddress = await bondingRegistry.getAddress();
+
+        // A wallet holding exactly one lock and an equal amount of free FOLD.
+        await allocate(ciphernodeBondToken, lockerAddress, BOND, "SLASH_LOCK");
+        await ciphernodeBondToken.mint(
+          lockerAddress,
+          BOND,
+          ethers.encodeBytes32String("Free"),
+        );
+
+        // Bonding the free half satisfies the lock, which frees the locked half to move.
+        await bondingRegistry
+          .connect(lockerOperator)
+          .setBondOwner(lockerAddress);
+        await ciphernodeBondToken
+          .connect(locker)
+          .approve(registryAddress, BOND);
+        await bondingRegistry
+          .connect(locker)
+          .bondCiphernodeFor(lockerOperatorAddress, BOND);
+
+        await ciphernodeBondToken.setTransferWhitelisted(sinkAddress, true);
+        await ciphernodeBondToken.connect(locker).transfer(sinkAddress, BOND);
+        expect(await ciphernodeBondToken.balanceOf(lockerAddress)).to.equal(0n);
+
+        // At this point the sum is honest: nothing in the wallet, the whole lock covered.
+        await time.increase(1);
+        expect(
+          await veBondedVotes.getPastVotes(
+            lockerAddress,
+            (await time.latest()) - 1,
+          ),
+        ).to.equal(BOND);
+
+        const managerAddress = await bondingRegistry.slashingManager();
+        await networkHelpers.setBalance(managerAddress, ethers.parseEther("1"));
+        await networkHelpers.impersonateAccount(managerAddress);
+        await bondingRegistry
+          .connect(await ethers.getSigner(managerAddress))
+          .slashCiphernodeBond(
+            lockerOperatorAddress,
+            BOND,
+            ethers.encodeBytes32String("TEST_SLASH"),
+          );
+        await networkHelpers.stopImpersonatingAccount(managerAddress);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        // The lock outlives the bond that covered it, so `locked - bonded` is the whole
+        // allocation — but the wallet holds none of it, and the slashed FOLD votes elsewhere.
+        expect(
+          await ciphernodeBondToken.lockedBalanceOf(lockerAddress),
+        ).to.equal(BOND);
+        expect(
+          await veBondedVotes.getPastVotes(lockerAddress, timepoint),
+        ).to.equal(0n);
+        expect(await veBondedVotes.getVotes(lockerAddress)).to.equal(0n);
+      });
+
+      /// The cap is a bound, not a source: it never lets an account vote with more than the
+      /// unbonded part of its lock, and never reaches into FOLD the lock does not encumber.
+      it("caps at the lock, not at the wallet balance", async function () {
+        const { veBondedVotes, ciphernodeBondToken, otherHolderAddress } =
+          await loadFixture(veSetup);
+
+        // The holder's wallet is far larger than the lock; only the locked part may vote.
+        await allocate(ciphernodeBondToken, otherHolderAddress, ALLOCATION);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await ciphernodeBondToken.balanceOf(otherHolderAddress),
+        ).to.be.greaterThan(ALLOCATION);
+        expect(
+          await veBondedVotes.getPastVotes(otherHolderAddress, timepoint),
+        ).to.equal(ALLOCATION);
+      });
+
+      /// When the token votes for itself, locked FOLD is wallet FOLD and the token's own
+      /// checkpoints already carry it. Adding the lock schedule there would double every locked
+      /// holder's weight.
+      it("is ignored when the votes source is the token itself", async function () {
+        const { bondedVotes, ciphernodeBondToken, otherHolderAddress } =
+          await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, otherHolderAddress, ALLOCATION);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await bondedVotes.getPastVotes(otherHolderAddress, timepoint),
+        ).to.equal(
+          await ciphernodeBondToken.getPastVotes(otherHolderAddress, timepoint),
+        );
+      });
     });
 
     it("records the escrow it resolved, and leaves it zero without one", async function () {

--- a/packages/interfold-contracts/test/Registry/BondedVotes.spec.ts
+++ b/packages/interfold-contracts/test/Registry/BondedVotes.spec.ts
@@ -68,6 +68,8 @@ describe("BondedVotes", function () {
 
     const bondedVotes = await ethers.deployContract("BondedVotes", [
       await ciphernodeBondToken.getAddress(),
+      // Votes source == the token: wallet-held FOLD votes, the original behaviour.
+      await ciphernodeBondToken.getAddress(),
       await checkpoints.getAddress(),
     ]);
 
@@ -755,6 +757,7 @@ describe("BondedVotes", function () {
       await expect(
         ethers.deployContract("BondedVotes", [
           await ciphernodeBondToken.getAddress(),
+          await ciphernodeBondToken.getAddress(),
           await foreign.getAddress(),
         ]),
       ).to.be.revert(ethers);
@@ -1115,6 +1118,228 @@ describe("BondedVotes", function () {
       expect(await bondingRegistry.bondedCheckpoints()).to.equal(
         await checkpoints.getAddress(),
       );
+    });
+  });
+  /// Lock-to-vote. `votesSource` is an escrow adapter instead of the token, so idle wallet FOLD
+  /// carries no weight and a holder must lock to participate — while an operator keeps its weight
+  /// by bonding, without locking anything.
+  ///
+  /// The property that makes this sound is that the DENOMINATOR stays on FOLD. Locked and bonded
+  /// FOLD were both transferred rather than burned, so both are still inside FOLD's total supply
+  /// and summed votes can never exceed it. Reading the denominator off the escrow instead would
+  /// omit the bonded half entirely and let participation exceed 100%.
+  describe("escrow votes source", function () {
+    const LOCKED = ethers.parseEther("4000");
+
+    async function veSetup() {
+      const base = await setup();
+      const { ciphernodeBondToken, checkpoints } = base;
+
+      const foldAddress = await ciphernodeBondToken.getAddress();
+      const escrow = await ethers.deployContract("MockVotingEscrow", [
+        foldAddress,
+      ]);
+      const adapter = await ethers.deployContract("MockEscrowVotesAdapter", [
+        await escrow.getAddress(),
+      ]);
+
+      const veBondedVotes = await ethers.deployContract("BondedVotes", [
+        foldAddress,
+        await adapter.getAddress(),
+        await checkpoints.getAddress(),
+      ]);
+
+      return { ...base, escrow, adapter, veBondedVotes, foldAddress };
+    }
+
+    it("counts locked FOLD and bonded FOLD, but not idle wallet FOLD", async function () {
+      const { veBondedVotes, adapter, bond, bondOwnerAddress } =
+        await loadFixture(veSetup);
+
+      // The holder has a large wallet balance and has self-delegated on the token itself, which
+      // under the original configuration would have been their entire voting power.
+      await bond(BOND);
+      await adapter.setVotes(bondOwnerAddress, LOCKED);
+
+      await time.increase(1);
+      const timepoint = (await time.latest()) - 1;
+
+      expect(
+        await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+      ).to.equal(LOCKED + BOND);
+      expect(await veBondedVotes.getVotes(bondOwnerAddress)).to.equal(
+        LOCKED + BOND,
+      );
+    });
+
+    it("gives a holder who locked nothing and bonded nothing no voting power", async function () {
+      const { veBondedVotes, otherHolderAddress } = await loadFixture(veSetup);
+
+      // Holds MINTED FOLD and has self-delegated on the token. Under lock-to-vote that is
+      // deliberately worth nothing.
+      await time.increase(1);
+      const timepoint = (await time.latest()) - 1;
+
+      expect(
+        await veBondedVotes.getPastVotes(otherHolderAddress, timepoint),
+      ).to.equal(0n);
+    });
+
+    it("lets an operator vote by bonding alone, without locking", async function () {
+      const { veBondedVotes, bond, bondOwnerAddress } =
+        await loadFixture(veSetup);
+
+      await bond(BOND);
+
+      await time.increase(1);
+      const timepoint = (await time.latest()) - 1;
+
+      expect(
+        await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+      ).to.equal(BOND);
+    });
+
+    /// The whole reason the token reference is kept separate from the votes source.
+    it("measures quorum against FOLD's supply, not the escrow's", async function () {
+      const {
+        veBondedVotes,
+        adapter,
+        ciphernodeBondToken,
+        bond,
+        bondOwnerAddress,
+      } = await loadFixture(veSetup);
+
+      await bond(BOND);
+      await adapter.setVotes(bondOwnerAddress, LOCKED);
+
+      await time.increase(1);
+      const timepoint = (await time.latest()) - 1;
+
+      // The adapter reports zero supply. Had the denominator been read from it, any turnout at
+      // all would have cleared every quorum.
+      expect(await adapter.getPastTotalSupply(timepoint)).to.equal(0n);
+
+      const supply = await veBondedVotes.getPastTotalSupply(timepoint);
+      expect(supply).to.equal(
+        await ciphernodeBondToken.getPastTotalSupply(timepoint),
+      );
+      expect(supply).to.be.greaterThan(0n);
+
+      // Soundness: what one account can vote with is inside the supply it is measured against.
+      expect(
+        await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+      ).to.be.lessThanOrEqual(supply);
+    });
+
+    /// The escrow adapter has no `decimals`, `name`, `symbol` or `totalSupply`. Routing metadata
+    /// through it would revert — and `decimals` reverting is the dangerous one, because CRISP's
+    /// tally scaling catches the failure and silently falls back to a scale of 1.
+    it("reads metadata from FOLD, which the escrow adapter cannot answer for", async function () {
+      const { veBondedVotes, adapter, ciphernodeBondToken } =
+        await loadFixture(veSetup);
+
+      expect(await veBondedVotes.decimals()).to.equal(
+        await ciphernodeBondToken.decimals(),
+      );
+      expect(await veBondedVotes.name()).to.equal(
+        await ciphernodeBondToken.name(),
+      );
+      expect(await veBondedVotes.symbol()).to.equal(
+        await ciphernodeBondToken.symbol(),
+      );
+      expect(await veBondedVotes.totalSupply()).to.equal(
+        await ciphernodeBondToken.totalSupply(),
+      );
+
+      // Not merely different — unanswerable, which is why it must not be asked.
+      const adapterAsToken = await ethers.getContractAt(
+        "BondedVotes",
+        await adapter.getAddress(),
+      );
+      await expect(adapterAsToken.decimals()).to.be.revert(ethers);
+    });
+
+    it("attributes locked FOLD to the locker in balanceOf", async function () {
+      const {
+        veBondedVotes,
+        adapter,
+        escrow,
+        ciphernodeBondToken,
+        bond,
+        bondOwnerAddress,
+      } = await loadFixture(veSetup);
+
+      await bond(BOND);
+      await escrow.setLocked(bondOwnerAddress, LOCKED);
+      await adapter.setVotes(bondOwnerAddress, LOCKED);
+
+      const wallet = await ciphernodeBondToken.balanceOf(bondOwnerAddress);
+
+      // Wallet plus what the escrow and the registry each custody on the account's behalf.
+      expect(await veBondedVotes.balanceOf(bondOwnerAddress)).to.equal(
+        wallet + LOCKED + BOND,
+      );
+    });
+
+    it("routes delegation lookups to the votes source", async function () {
+      const { veBondedVotes, adapter, bondOwnerAddress, otherHolderAddress } =
+        await loadFixture(veSetup);
+
+      await adapter.setDelegate(bondOwnerAddress, otherHolderAddress);
+
+      expect(await veBondedVotes.delegates(bondOwnerAddress)).to.equal(
+        otherHolderAddress,
+      );
+    });
+
+    /// Same argument as `TokenMismatch`, applied to the other half of the numerator: an escrow
+    /// over a different token would mint voting power FOLD's supply does not back, and the
+    /// denominator would never reveal it.
+    it("rejects an escrow that custodies a different token", async function () {
+      const { checkpoints, foldAddress } = await loadFixture(veSetup);
+
+      const foreignToken = await (
+        await ethers.getContractFactory("MockLockAwareCiphernodeBondToken")
+      ).deploy(0);
+      const foreignEscrow = await ethers.deployContract("MockVotingEscrow", [
+        await foreignToken.getAddress(),
+      ]);
+      const foreignAdapter = await ethers.deployContract(
+        "MockEscrowVotesAdapter",
+        [await foreignEscrow.getAddress()],
+      );
+
+      await expect(
+        ethers.deployContract("BondedVotes", [
+          foldAddress,
+          await foreignAdapter.getAddress(),
+          await checkpoints.getAddress(),
+        ]),
+      ).to.be.revert(ethers);
+    });
+
+    it("rejects a votes source whose clock disagrees with the token", async function () {
+      const { checkpoints, adapter, foldAddress } = await loadFixture(veSetup);
+
+      // A block-numbered escrow summed with a timestamp-keyed history answers for two unrelated
+      // instants, and nothing downstream could detect it.
+      await adapter.setClock(1);
+
+      await expect(
+        ethers.deployContract("BondedVotes", [
+          foldAddress,
+          await adapter.getAddress(),
+          await checkpoints.getAddress(),
+        ]),
+      ).to.be.revert(ethers);
+    });
+
+    it("records the escrow it resolved, and leaves it zero without one", async function () {
+      const { veBondedVotes, bondedVotes, escrow } = await loadFixture(veSetup);
+
+      expect(await veBondedVotes.escrow()).to.equal(await escrow.getAddress());
+      // The original configuration resolves no escrow, so balanceOf never consults one.
+      expect(await bondedVotes.escrow()).to.equal(ethers.ZeroAddress);
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable voting sources, including escrow-locked FOLD.
  - Voting power now accounts for bonded, vesting-locked, and escrowed balances while preventing double counting.
  - Added timestamp-based locked-balance queries for accurate governance snapshots.
  - Added configuration and deployment support for escrow-based voting, including locked-only or wallet-inclusive voting modes.

- **Bug Fixes**
  - Improved balance netting, quorum supply calculations, slashing caps, and escrow custody attribution.
  - Added validation for compatible tokens, clocks, registries, and voting sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->