### PR TITLE
chore: show more data on dashboard

### DIFF
--- a/packages/interfold-dashboard/README.md
+++ b/packages/interfold-dashboard/README.md
@@ -35,6 +35,8 @@ against `packages/interfold-contracts/deployed_contracts.json` for the target ne
 - `CiphernodeRegistryOwnable` — `CommitteeRequested` (threshold + seed), `CommitteeFinalized`
   (members), `CommitteePublished` (joint PK).
 - `BondingRegistry` — operator collateral and the write path behind the operator guide (see below).
+  Also feeds the network pulse strip: `totalCiphernodeBondLiability` (total bonded) and
+  `eligibilityAt` (active operator count), alongside `numCiphernodes` from the ciphernode registry.
 - `CRISPProgram` — emits `InputPublished` for every ballot. (Interfold's own `InputPublished` is
   declared but never emitted; inputs live on the program.) A re-vote reuses its Merkle-leaf `index`,
   so the true ballot count is the number of **distinct** indexes. Inputs are only observable for

--- a/packages/interfold-dashboard/src/App.tsx
+++ b/packages/interfold-dashboard/src/App.tsx
@@ -15,6 +15,7 @@ import Inspector from './Inspector'
 import Loader from './Loader'
 import Operator from './Operator'
 import { useAllE3s, useCrispPolls, useE3Details, useRecentBallots } from './lib/useE3s'
+import { useNetworkStats } from './lib/network'
 import { adaptHistoryEntries, adaptInspectorDetail, adaptInspectorE3List, adaptPoll } from './lib/adapt'
 import { formatE3Id } from './lib/pollMeta'
 import { LINKS, explorerAddress } from './lib/links'
@@ -186,6 +187,7 @@ export default function App() {
   const crispPolls = useCrispPolls()
   const allE3s = useAllE3s()
   const recentBallots = useRecentBallots()
+  const networkStats = useNetworkStats()
 
   // Inspector keeps its own selection — track which id is currently selected.
   const [inspectorIdStr, setInspectorIdStr] = useState<string | null>(null)
@@ -300,6 +302,14 @@ export default function App() {
   return (
     <div className={`page page--${DENSITY}`}>
       <Header density={DENSITY} view={view} onNav={navigate} />
+      <Pulse
+        data={{
+          activeNow: activePolls.length,
+          ballots24h: recentBallots,
+          pollsAllTime: polls.length,
+        }}
+        network={networkStats}
+      />
       {view === 'operator' ? (
         <main className='main'>
           <Operator />
@@ -383,13 +393,6 @@ export default function App() {
         </main>
       )}
 
-      <Pulse
-        data={{
-          activeNow: activePolls.length,
-          ballots24h: recentBallots,
-          pollsAllTime: polls.length,
-        }}
-      />
       <SiteFooter />
     </div>
   )

--- a/packages/interfold-dashboard/src/Pulse.tsx
+++ b/packages/interfold-dashboard/src/Pulse.tsx
@@ -3,34 +3,54 @@
 // This file is provided WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
-// Network pulse — small, low-emphasis footer strip.
+// Network pulse — stat card at the top of every view.
 
-export default function Pulse({ data }: { data: { activeNow: number; ballots24h: number; pollsAllTime: number } }) {
+import { formatUnits } from 'viem'
+import type { NetworkStats } from './lib/network'
+import { NETWORK_NAME } from './lib/chain'
+
+// Human-scale token amount, compacted above 10k (96,000 → "96K").
+function fmtBonded(value: bigint, decimals: number): string {
+  const asNumber = Number(formatUnits(value, decimals))
+  if (asNumber >= 10_000) {
+    return asNumber.toLocaleString(undefined, { notation: 'compact', maximumFractionDigits: 1 })
+  }
+  return asNumber.toLocaleString(undefined, { maximumFractionDigits: asNumber >= 1000 ? 0 : 2 })
+}
+
+function Tile({ value, label }: { value: string; label: string }) {
   return (
-    <section className='pulse' aria-label='Network activity'>
-      <div className='pulse__inner'>
-        <div className='pulse__brand'>
-          <span className='pulse__brand-mark' aria-hidden='true' />
-          <span>Interfold network</span>
-        </div>
-        <div className='pulse__metrics'>
-          <div className='pulse__metric'>
-            <span className='pulse__metric-num mono'>{data.activeNow}</span>
-            <span className='pulse__metric-label'>active E3{data.activeNow === 1 ? '' : 's'} right now</span>
-          </div>
-          <div className='pulse__metric'>
-            <span className='pulse__metric-num mono'>{data.ballots24h.toLocaleString()}</span>
-            <span className='pulse__metric-label'>encrypted ballots, last 24h</span>
-          </div>
-          <div className='pulse__metric'>
-            <span className='pulse__metric-num mono'>{data.pollsAllTime.toLocaleString()}</span>
-            <span className='pulse__metric-label'>CRISP polls, all-time</span>
-          </div>
-        </div>
-        <div className='pulse__status'>
-          <span className='pulse__status-dot' />
-          <span>All systems nominal</span>
-        </div>
+    <div className='netpulse__tile'>
+      <div className='netpulse__value'>{value}</div>
+      <div className='netpulse__label'>{label}</div>
+    </div>
+  )
+}
+
+export default function Pulse({
+  data,
+  network,
+}: {
+  data: { activeNow: number; ballots24h: number; pollsAllTime: number }
+  network: NetworkStats | null
+}) {
+  return (
+    <section className='netpulse' aria-label='Network activity'>
+      <div className='netpulse__head'>
+        <span className='dot-live' aria-hidden='true' />
+        <span className='netpulse__title'>Interfold network</span>
+        <span className='netpulse__net'>{NETWORK_NAME}</span>
+      </div>
+      <div className='netpulse__grid'>
+        <Tile value={network ? network.registeredNodes.toLocaleString() : '—'} label='ciphernodes registered' />
+        <Tile value={network ? network.activeOperators.toLocaleString() : '—'} label='active now' />
+        <Tile
+          value={network ? fmtBonded(network.totalBonded, network.bondDecimals) : '—'}
+          label={`${network?.bondSymbol ?? ''} bonded`.trim() || 'bonded'}
+        />
+        <Tile value={String(data.activeNow)} label={`active E3${data.activeNow === 1 ? '' : 's'} right now`} />
+        <Tile value={data.ballots24h.toLocaleString()} label='encrypted ballots, last 24h' />
+        <Tile value={data.pollsAllTime.toLocaleString()} label='CRISP polls, all-time' />
       </div>
     </section>
   )

--- a/packages/interfold-dashboard/src/lib/network.ts
+++ b/packages/interfold-dashboard/src/lib/network.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+// Network-wide operator stats for the public pulse strip.
+
+import { erc20Abi, type Address } from 'viem'
+import { useEffect, useRef, useState } from 'react'
+import { CONTRACTS, bondingRegistryAbi, ciphernodeRegistryAbi, publicClient } from './chain'
+
+// Node counts and total bonded move slowly — poll at a fraction of the E3 rate
+// so the strip does not add load to rate-limited free-tier RPCs.
+const POLL_MS = 60_000
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as Address
+
+export type NetworkStats = {
+  /** Ciphernodes currently in the registry tree. */
+  registeredNodes: bigint
+  /** Operators active (bonded + ticketed) right now. */
+  activeOperators: bigint
+  /** Total ciphernode bond collateral held by the bonding registry. */
+  totalBonded: bigint
+  bondSymbol: string
+  bondDecimals: number
+}
+
+// Bond-token metadata never changes for a deployment — resolved on the first
+// successful fetch, then reused so later ticks cost a single multicall.
+let tokenMeta: { symbol: string; decimals: number } | null = null
+
+export async function fetchNetworkStats(): Promise<NetworkStats> {
+  // eligibilityAt keys its checkpoint lookup by timestamp; "now" returns the
+  // latest value. The operator argument only affects the per-operator flag,
+  // which we ignore, so the zero address works for the global count.
+  const nowSec = BigInt(Math.floor(Date.now() / 1000))
+  // Multicall keeps this to one eth_call per tick (two on the first), so the
+  // strip cannot crowd out the other fetchers on batch-capped RPC providers.
+  const [registeredNodes, [, activeOperators], totalBonded, bondToken] = (await (publicClient.multicall as any)({
+    allowFailure: false,
+    contracts: [
+      { address: CONTRACTS.CiphernodeRegistry, abi: ciphernodeRegistryAbi, functionName: 'numCiphernodes' },
+      { address: CONTRACTS.BondingRegistry, abi: bondingRegistryAbi, functionName: 'eligibilityAt', args: [ZERO_ADDRESS, nowSec] },
+      { address: CONTRACTS.BondingRegistry, abi: bondingRegistryAbi, functionName: 'totalCiphernodeBondLiability' },
+      { address: CONTRACTS.BondingRegistry, abi: bondingRegistryAbi, functionName: 'getCiphernodeBondToken' },
+    ],
+  })) as [bigint, [boolean, bigint], bigint, Address]
+
+  if (!tokenMeta) {
+    const [symbol, decimals] = (await (publicClient.multicall as any)({
+      allowFailure: false,
+      contracts: [
+        { address: bondToken, abi: erc20Abi, functionName: 'symbol' },
+        { address: bondToken, abi: erc20Abi, functionName: 'decimals' },
+      ],
+    })) as [string, number]
+    tokenMeta = { symbol, decimals: Number(decimals) }
+  }
+
+  return {
+    registeredNodes,
+    activeOperators,
+    totalBonded,
+    bondSymbol: tokenMeta.symbol,
+    bondDecimals: tokenMeta.decimals,
+  }
+}
+
+// Network stats for the pulse strip (null until first load; keeps the last
+// value on transient errors, matching useRecentBallots).
+export function useNetworkStats(): NetworkStats | null {
+  const [stats, setStats] = useState<NetworkStats | null>(null)
+  const mounted = useRef(true)
+
+  useEffect(() => {
+    mounted.current = true
+    let cancelled = false
+    let inFlight = false
+    const tick = async () => {
+      if (inFlight) return
+      inFlight = true
+      try {
+        const next = await fetchNetworkStats()
+        if (!cancelled && mounted.current) setStats(next)
+      } catch {
+        /* keep last value on transient errors */
+      } finally {
+        inFlight = false
+      }
+    }
+    // Stay out of the mount burst (E3 list getLogs + operator-guide reads) so a
+    // rate-limited RPC serves the page-critical fetchers first.
+    const first = setTimeout(tick, 2_500)
+    const id = setInterval(tick, POLL_MS)
+    return () => {
+      cancelled = true
+      mounted.current = false
+      clearTimeout(first)
+      clearInterval(id)
+    }
+  }, [])
+
+  return stats
+}

--- a/packages/interfold-dashboard/src/styles.css
+++ b/packages/interfold-dashboard/src/styles.css
@@ -1145,69 +1145,102 @@ button {
   }
 }
 
-/* ── Network pulse ──────────────────────────────────────────────────────── */
-.pulse {
-  border-top: 1px solid var(--rule);
-  background: var(--paper);
-}
-.pulse__inner {
+/* ── Network pulse (stat card below the header) ─────────────────────────── */
+.netpulse {
+  width: 100%;
   max-width: var(--maxw);
-  margin: 0 auto;
-  padding: 18px 32px;
-  display: flex;
-  align-items: center;
-  gap: 32px;
-  flex-wrap: wrap;
+  margin: 40px auto 0;
+  padding: 0 32px;
 }
-.pulse__brand {
+.netpulse__head {
   display: flex;
   align-items: center;
   gap: 10px;
+  margin-bottom: 12px;
   font-size: 12px;
-  color: var(--ink-3);
   font-weight: 540;
+  color: var(--ink-3);
   letter-spacing: -0.005em;
 }
-.pulse__brand-mark {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--accent-deep);
+.netpulse__title {
+  color: var(--ink-2);
 }
-.pulse__metrics {
-  display: flex;
-  gap: 28px;
-  flex-wrap: wrap;
+.netpulse__net {
+  padding: 2px 9px;
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  background: var(--paper-2);
+  font-size: 11px;
+  color: var(--ink-3);
 }
-.pulse__metric {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
+.netpulse__grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  background: var(--paper-2);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow:
+    0 1px 0 rgba(20, 32, 27, 0.02),
+    0 12px 32px -20px rgba(20, 32, 27, 0.18);
 }
-.pulse__metric-num {
-  font-size: 15px;
-  font-weight: 500;
+.netpulse__tile {
+  padding: 20px 22px 18px;
+  min-width: 0;
+}
+.netpulse__tile + .netpulse__tile {
+  border-left: 1px solid var(--rule-soft);
+}
+.netpulse__value {
+  font-size: 26px;
+  font-weight: 560;
   color: var(--ink);
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
 }
-.pulse__metric-label {
+.netpulse__label {
+  margin-top: 4px;
   font-size: 12px;
   color: var(--ink-3);
 }
-.pulse__status {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: var(--ink-3);
+@media (max-width: 980px) {
+  .netpulse__grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  /* Wrapped rows: keep the vertical divider off the row starts, rule the rows apart. */
+  .netpulse__tile + .netpulse__tile {
+    border-left: none;
+  }
+  .netpulse__tile:not(:nth-child(3n + 1)) {
+    border-left: 1px solid var(--rule-soft);
+  }
+  .netpulse__tile:nth-child(n + 4) {
+    border-top: 1px solid var(--rule-soft);
+  }
 }
-.pulse__status-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent-deep);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent-deep) 18%, transparent);
+@media (max-width: 560px) {
+  .netpulse {
+    margin-top: 24px;
+    padding: 0 18px;
+  }
+  .netpulse__grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .netpulse__tile {
+    padding: 16px 18px 14px;
+  }
+  .netpulse__tile:not(:nth-child(3n + 1)) {
+    border-left: none;
+  }
+  .netpulse__tile:not(:nth-child(2n + 1)) {
+    border-left: 1px solid var(--rule-soft);
+  }
+  .netpulse__tile:nth-child(n + 3) {
+    border-top: 1px solid var(--rule-soft);
+  }
+  .netpulse__value {
+    font-size: 22px;
+  }
 }
 
 /* ── Footer ─────────────────────────────────────────────────────────────── */
@@ -1392,17 +1425,6 @@ button {
   }
   .hist-row__chev {
     display: none;
-  }
-
-  .pulse__inner {
-    padding: 16px 18px;
-    gap: 14px;
-  }
-  .pulse__metrics {
-    gap: 16px 22px;
-  }
-  .pulse__status {
-    margin-left: 0;
   }
 
   .site-foot__inner {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a top-level network pulse card displaying the network name, registered nodes, active operators, bonded amount, and activity metrics.
  * Network statistics now refresh periodically and remain visible during temporary data-fetching issues.
  * Added compact formatting for large bonded token amounts, with clear fallbacks when data is unavailable.

* **Style**
  * Redesigned the pulse display with a responsive statistics grid for desktop, tablet, and mobile layouts.

* **Documentation**
  * Updated dashboard documentation to describe the additional network pulse metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->