### PR TITLE
fix(net): harden startup buffering and connection logs

### DIFF
--- a/agent/CRATES_ARCHITECTURE.md
+++ b/agent/CRATES_ARCHITECTURE.md
@@ -425,11 +425,12 @@ flowchart LR
     Identify -->|accepted| Signed[application-validated signed gossipsub]
     Identify -->|rejected| Drop[disconnect and suppress repeated warnings]
     Signed --> Envelope[network, deployment, schema, aggregate, and hash checks]
-    Envelope --> Raw[bounded NetEvent broadcast]
-    Raw --> AppFilter{application delivery event?}
-    AppFilter -->|yes| Startup[NetEventBuffer count + byte limits]
-    AppFilter -->|no| Control[raw sync / connection consumer only]
+    Envelope --> EventRouter{application delivery event?}
+    EventRouter --> Raw[bounded raw NetEvent broadcast]
+    EventRouter -->|yes| App[bounded application broadcast]
+    EventRouter -->|no| Control[raw channel only]
     Raw --> SyncManager[NetSyncManager]
+    App --> Startup[NetEventBuffer count + byte limits]
     Startup -->|await actor acceptance after SyncEnded| Translator[NetEventTranslator]
     Translator --> Allowlist{forwardable event type?}
     Allowlist -->|yes| Domain[bounded decode to InterfoldEvent]
@@ -464,10 +465,11 @@ ID, schema version, and payload hash. Gossipsub and direct-request/DHT decoding 
 limits. Translation actors accept only the protocol event allowlist before publishing remote events,
 and their broadcast-to-actor ingress loops await mailbox acceptance and stop when the destination
 actor closes. Each publish attempt has a result timeout. No-peer failures use a longer retry window
-than other transient failures. The startup buffer admits only gossip payloads and publish or DHT
-results that post-sync application consumers use. Historical-sync and connection-control events
-remain available on the raw receiver but do not consume the application buffer or its actor mailbox.
-The application buffer is bounded by both event count and estimated bytes and fails readiness on
+than other transient failures. The network producer sends all events to the raw channel. It also
+sends gossip payloads and publish or DHT results to a separate application channel. The startup
+buffer subscribes only to the application channel. Historical-sync and connection-control bursts
+cannot lag the application receiver or consume its actor mailbox. The application buffer is bounded
+by both event count and estimated bytes and fails readiness on
 overflow or broadcast lag; after `SyncEnded`, broadcast lag is warned and skipped without stopping
 the ingress loop. Historical direct sync requires advancing cursors and
 enforces one cumulative page, event, byte, and time budget across all aggregate fetches and recovery

--- a/agent/CRATES_ARCHITECTURE.md
+++ b/agent/CRATES_ARCHITECTURE.md
@@ -426,7 +426,9 @@ flowchart LR
     Identify -->|rejected| Drop[disconnect and suppress repeated warnings]
     Signed --> Envelope[network, deployment, schema, aggregate, and hash checks]
     Envelope --> Raw[bounded NetEvent broadcast]
-    Raw --> Startup[NetEventBuffer count + byte limits]
+    Raw --> AppFilter{application delivery event?}
+    AppFilter -->|yes| Startup[NetEventBuffer count + byte limits]
+    AppFilter -->|no| Control[raw sync / connection consumer only]
     Raw --> SyncManager[NetSyncManager]
     Startup -->|await actor acceptance after SyncEnded| Translator[NetEventTranslator]
     Translator --> Allowlist{forwardable event type?}
@@ -462,9 +464,12 @@ ID, schema version, and payload hash. Gossipsub and direct-request/DHT decoding 
 limits. Translation actors accept only the protocol event allowlist before publishing remote events,
 and their broadcast-to-actor ingress loops await mailbox acceptance and stop when the destination
 actor closes. Each publish attempt has a result timeout. No-peer failures use a longer retry window
-than other transient failures. Startup buffering is bounded by both event count and estimated bytes
-and fails readiness on overflow or broadcast lag; after `SyncEnded`, broadcast lag is warned and
-skipped without stopping the ingress loop. Historical direct sync requires advancing cursors and
+than other transient failures. The startup buffer admits only gossip payloads and publish or DHT
+results that post-sync application consumers use. Historical-sync and connection-control events
+remain available on the raw receiver but do not consume the application buffer or its actor mailbox.
+The application buffer is bounded by both event count and estimated bytes and fails readiness on
+overflow or broadcast lag; after `SyncEnded`, broadcast lag is warned and skipped without stopping
+the ingress loop. Historical direct sync requires advancing cursors and
 enforces one cumulative page, event, byte, and time budget across all aggregate fetches and recovery
 retries in a startup attempt. Bootstrap dialing makes three bounded startup attempts and then
 retries unavailable peers every 60 seconds in the background. Kademlia peers are evicted after three

--- a/agent/flow-trace/06_DEACTIVATION_AND_COMPLETION.md
+++ b/agent/flow-trace/06_DEACTIVATION_AND_COMPLETION.md
@@ -299,7 +299,10 @@ receive task. A lag can still drop the reported `n` events, but a single burst n
 disables gossip translation, document notifications, or historical-sync/readiness handling.
 `NetEventBuffer` applies the same continue policy only after `SyncEnded`; lag during its startup
 buffering window remains a fail-closed readiness error because those skipped events cannot yet be
-reconciled safely.
+reconciled safely. Before events reach its mailbox, the buffer admits only gossip payloads and
+publish or DHT results that post-sync application consumers use. Historical-sync and
+connection-control events remain on the raw receiver for `NetSyncManager`; they do not consume the
+application startup buffer.
 
 EventStore replay uses a disk-backed external merge: per-aggregate pages are sorted into secure
 temporary runs, then compacted and merged with bounded file-descriptor fan-in. Replay waits for

--- a/agent/flow-trace/06_DEACTIVATION_AND_COMPLETION.md
+++ b/agent/flow-trace/06_DEACTIVATION_AND_COMPLETION.md
@@ -299,10 +299,10 @@ receive task. A lag can still drop the reported `n` events, but a single burst n
 disables gossip translation, document notifications, or historical-sync/readiness handling.
 `NetEventBuffer` applies the same continue policy only after `SyncEnded`; lag during its startup
 buffering window remains a fail-closed readiness error because those skipped events cannot yet be
-reconciled safely. Before events reach its mailbox, the buffer admits only gossip payloads and
-publish or DHT results that post-sync application consumers use. Historical-sync and
-connection-control events remain on the raw receiver for `NetSyncManager`; they do not consume the
-application startup buffer.
+reconciled safely. The network producer sends all events to the raw channel. It sends only gossip
+payloads and publish or DHT results to a separate application channel. `NetEventBuffer` subscribes
+to the application channel. Historical-sync and connection-control bursts remain on the raw channel
+and cannot lag or consume the application startup buffer.
 
 EventStore replay uses a disk-backed external merge: per-aggregate pages are sorted into secure
 temporary runs, then compacted and merged with bounded file-descriptor fan-in. Replay waits for

--- a/crates/ciphernode-builder/src/ciphernode_builder.rs
+++ b/crates/ciphernode-builder/src/ciphernode_builder.rs
@@ -32,8 +32,8 @@ use e3_keyshare::ext::ThresholdKeyshareExtension;
 use e3_logger::attach_protocol_logger;
 use e3_multithread::{Multithread, MultithreadReport, TaskPool};
 use e3_net::{
-    create_channel_bridge, setup_libp2p_keypair, setup_net_interface, setup_net_with_limits,
-    NetRepositoryFactory, NetworkPolicy,
+    create_channel_bridge_with_application_event_capacity, setup_libp2p_keypair,
+    setup_net_interface, setup_net_with_limits, NetRepositoryFactory, NetworkPolicy,
 };
 use e3_request::{
     ensure_request_router_checkpoint, load_dkg_fold_attestation_contexts, E3LifecycleCoordinator,
@@ -966,10 +966,12 @@ impl CiphernodeBuilder {
                 keypair,
                 net_config.peers.clone(),
                 net_config.quic_port,
+                self.max_buffered_net_events,
             )?;
             Ok((peer_id, interface, NetInterfaceKind::Libp2p))
         } else {
-            let (interface, channel_bridge) = create_channel_bridge();
+            let (interface, channel_bridge) =
+                create_channel_bridge_with_application_event_capacity(self.max_buffered_net_events);
             let peer_id = PeerId::random();
             Ok((
                 peer_id,

--- a/crates/net/src/dialer.rs
+++ b/crates/net/src/dialer.rs
@@ -18,7 +18,10 @@ use tracing::info;
 use tracing::trace;
 use tracing::warn;
 
-use crate::events::{NetCommand, NetEvent, PeerRejectionKind};
+use crate::{
+    events::{NetCommand, NetEvent, PeerRejectionKind},
+    NetEventSender,
+};
 use e3_utils::{to_retry, OnceTake, RetryError};
 
 const INITIAL_DIAL_ATTEMPTS: u32 = 3;
@@ -36,7 +39,7 @@ enum InitialDialError {
 /// Dial one address during the bounded startup phase.
 async fn dial_multiaddr(
     cmd_tx: &mpsc::Sender<NetCommand>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     multiaddr_str: &str,
 ) -> std::result::Result<(), InitialDialError> {
     let multiaddr: Multiaddr = multiaddr_str
@@ -76,7 +79,7 @@ async fn dial_multiaddr(
 
 async fn retry_multiaddr_in_background(
     cmd_tx: mpsc::Sender<NetCommand>,
-    event_tx: broadcast::Sender<NetEvent>,
+    event_tx: NetEventSender,
     multiaddr_str: String,
 ) {
     let Ok(multiaddr) = multiaddr_str.parse() else {
@@ -118,7 +121,7 @@ async fn retry_multiaddr_in_background(
 /// The number of peers that were successfully connected to.
 pub async fn dial_peers(
     cmd_tx: &mpsc::Sender<NetCommand>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     peers: &[String],
 ) -> Result<usize> {
     let futures: Vec<_> = peers
@@ -166,7 +169,7 @@ pub async fn dial_peers(
 /// Attempt a connection with retries to a multiaddr.
 async fn attempt_connection(
     cmd_tx: &mpsc::Sender<NetCommand>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     multiaddr: &Multiaddr,
 ) -> Result<(), RetryError> {
     let mut event_rx = event_tx.subscribe();

--- a/crates/net/src/event_buffer/actor.rs
+++ b/crates/net/src/event_buffer/actor.rs
@@ -34,9 +34,9 @@ impl NetEventBufferHandle {
     }
 }
 
-/// Actor that controls a broadcast channel which will buffer NetEvents until it receives a
-/// `SyncEnded` event, at which time it releases all buffered events to the output channel. The
-/// buffering decision logic lives in [`NetEventBufferState`].
+/// Actor that buffers application NetEvents until it receives `SyncEnded` and then releases them
+/// to the output channel. Sync and connection-control events bypass this actor. The buffering
+/// decision logic lives in [`NetEventBufferState`].
 pub struct NetEventBuffer {
     state: NetEventBufferState,
     input_rx: Option<broadcast::Receiver<NetEvent>>,

--- a/crates/net/src/event_buffer/handlers.rs
+++ b/crates/net/src/event_buffer/handlers.rs
@@ -23,11 +23,12 @@ impl Actor for NetEventBuffer {
         actix::spawn(async move {
             loop {
                 match input_rx.recv().await {
-                    Ok(event) => {
+                    Ok(event) if event.requires_application_delivery() => {
                         if addr.send(IncomingNetEvent(event)).await.is_err() {
                             break;
                         }
                     }
+                    Ok(_) => {}
                     Err(RecvError::Lagged(skipped)) => {
                         if addr.send(NetInputLagged(skipped)).await.is_err() {
                             break;
@@ -50,6 +51,9 @@ impl Handler<IncomingNetEvent> for NetEventBuffer {
     type Result = ();
 
     fn handle(&mut self, msg: IncomingNetEvent, ctx: &mut Self::Context) {
+        if !msg.0.requires_application_delivery() {
+            return;
+        }
         let event_bytes = if self.state.is_running() {
             0
         } else {

--- a/crates/net/src/event_buffer/tests.rs
+++ b/crates/net/src/event_buffer/tests.rs
@@ -7,10 +7,9 @@
 use std::time::Duration;
 
 use super::*;
-use crate::events::{GossipData, NetEvent};
+use crate::events::{GossipData, NetEvent, OutgoingRequestSucceeded, ProtocolResponse};
 use e3_ciphernode_builder::EventSystem;
-use e3_events::EventPublisher;
-use e3_events::SyncEnded;
+use e3_events::{CorrelationId, EventPublisher, SyncEnded};
 use tokio::{
     sync::broadcast,
     time::{sleep, timeout},
@@ -122,5 +121,39 @@ async fn startup_buffer_enforces_estimated_payload_bytes() -> Result<()> {
         error.contains(&format!("next_event_bytes={estimated_bytes}")),
         "{error}"
     );
+    Ok(())
+}
+
+#[actix::test]
+async fn sync_control_flood_does_not_consume_the_application_buffer() -> Result<()> {
+    const CONTROL_EVENTS: usize = 100_000;
+
+    let system = EventSystem::new().with_fresh_bus();
+    let bus = system.handle()?.enable("net-control-flood");
+    let (input_tx, input_rx) = broadcast::channel(CONTROL_EVENTS.next_power_of_two());
+    let (mut output_rx, handle) =
+        NetEventBuffer::setup_with_limits(&bus, &input_rx, 1, DEFAULT_MAX_BUFFERED_NET_BYTES);
+
+    for _ in 0..CONTROL_EVENTS {
+        input_tx.send(NetEvent::OutgoingRequestSucceeded(
+            OutgoingRequestSucceeded {
+                payload: ProtocolResponse::Ok(Vec::new()),
+                correlation_id: CorrelationId::new(),
+            },
+        ))?;
+    }
+    input_tx.send(NetEvent::GossipData(GossipData::GossipBytes(vec![7])))?;
+    bus.publish_without_context(SyncEnded::new())?;
+
+    handle.wait_until_running().await?;
+    let forwarded = timeout(Duration::from_secs(5), output_rx.recv()).await??;
+    assert!(matches!(
+        forwarded,
+        NetEvent::GossipData(GossipData::GossipBytes(bytes)) if bytes == vec![7]
+    ));
+    assert!(matches!(
+        output_rx.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
     Ok(())
 }

--- a/crates/net/src/event_buffer/tests.rs
+++ b/crates/net/src/event_buffer/tests.rs
@@ -4,16 +4,73 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use super::*;
-use crate::events::{GossipData, NetEvent, OutgoingRequestSucceeded, ProtocolResponse};
+use crate::{
+    direct_responder::{ChannelType, DirectResponder},
+    events::{
+        GossipData, IncomingRequest, NetEvent, OutgoingRequestFailed, OutgoingRequestSucceeded,
+        PeerRejectionKind, ProtocolResponse,
+    },
+};
 use e3_ciphernode_builder::EventSystem;
 use e3_events::{CorrelationId, EventPublisher, SyncEnded};
+use libp2p::{
+    gossipsub::TopicHash,
+    swarm::{ConnectionId, DialError},
+    PeerId,
+};
 use tokio::{
-    sync::broadcast,
+    sync::{broadcast, mpsc},
     time::{sleep, timeout},
 };
+
+fn sync_and_connection_control_events() -> Vec<NetEvent> {
+    let (command_tx, _command_rx) = mpsc::channel(1);
+    vec![
+        NetEvent::DialError {
+            error: Arc::new(DialError::NoAddresses),
+        },
+        NetEvent::ConnectionEstablished {
+            connection_id: ConnectionId::new_unchecked(1),
+        },
+        NetEvent::PeerRejected {
+            connection_id: ConnectionId::new_unchecked(2),
+            kind: PeerRejectionKind::Transient,
+            reason: "test rejection".to_owned(),
+        },
+        NetEvent::OutgoingConnectionError {
+            connection_id: ConnectionId::new_unchecked(3),
+            error: Arc::new(DialError::NoAddresses),
+        },
+        NetEvent::GossipSubscribed {
+            count: 1,
+            topic: TopicHash::from_raw("test-topic"),
+        },
+        NetEvent::IncomingRequest(IncomingRequest {
+            peer: PeerId::random(),
+            responder: DirectResponder::new(
+                1_u64,
+                ChannelType::Test("test-request".to_owned()),
+                &command_tx,
+            )
+            .with_request(vec![1, 2, 3]),
+        }),
+        NetEvent::OutgoingRequestSucceeded(OutgoingRequestSucceeded {
+            payload: ProtocolResponse::Ok(Vec::new()),
+            correlation_id: CorrelationId::new(),
+        }),
+        NetEvent::OutgoingRequestFailed(OutgoingRequestFailed {
+            correlation_id: CorrelationId::new(),
+            error: "test request failure".to_owned(),
+        }),
+        NetEvent::AllPeersDialed {
+            connected: 1,
+            total: 1,
+        },
+    ]
+}
 
 #[actix::test]
 async fn test_buffers_until_sync_ended() -> Result<()> {
@@ -130,18 +187,23 @@ async fn sync_control_flood_does_not_consume_the_application_buffer() -> Result<
 
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle()?.enable("net-control-flood");
-    let (input_tx, input_rx) = broadcast::channel(CONTROL_EVENTS.next_power_of_two());
+    let (input_tx, input_rx) = broadcast::channel(1_024);
     let (mut output_rx, handle) =
         NetEventBuffer::setup_with_limits(&bus, &input_rx, 1, DEFAULT_MAX_BUFFERED_NET_BYTES);
 
-    for _ in 0..CONTROL_EVENTS {
-        input_tx.send(NetEvent::OutgoingRequestSucceeded(
-            OutgoingRequestSucceeded {
-                payload: ProtocolResponse::Ok(Vec::new()),
-                correlation_id: CorrelationId::new(),
-            },
-        ))?;
-    }
+    let control_events = sync_and_connection_control_events();
+    assert!(control_events
+        .iter()
+        .all(|event| !event.requires_application_delivery()));
+
+    let producer = actix::spawn(async move {
+        for index in 0..CONTROL_EVENTS {
+            input_tx.send(control_events[index % control_events.len()].clone())?;
+            tokio::task::yield_now().await;
+        }
+        anyhow::Ok(input_tx)
+    });
+    let input_tx = producer.await??;
     input_tx.send(NetEvent::GossipData(GossipData::GossipBytes(vec![7])))?;
     bus.publish_without_context(SyncEnded::new())?;
 

--- a/crates/net/src/event_buffer/tests.rs
+++ b/crates/net/src/event_buffer/tests.rs
@@ -13,6 +13,8 @@ use crate::{
         GossipData, IncomingRequest, NetEvent, OutgoingRequestFailed, OutgoingRequestSucceeded,
         PeerRejectionKind, ProtocolResponse,
     },
+    net_interface::EVENT_CHANNEL_SIZE,
+    NetEventSender,
 };
 use e3_ciphernode_builder::EventSystem;
 use e3_events::{CorrelationId, EventPublisher, SyncEnded};
@@ -182,12 +184,14 @@ async fn startup_buffer_enforces_estimated_payload_bytes() -> Result<()> {
 }
 
 #[actix::test]
-async fn sync_control_flood_does_not_consume_the_application_buffer() -> Result<()> {
+async fn sync_control_burst_does_not_lag_or_consume_the_application_buffer() -> Result<()> {
     const CONTROL_EVENTS: usize = 100_000;
 
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle()?.enable("net-control-flood");
-    let (input_tx, input_rx) = broadcast::channel(1_024);
+    let event_tx = NetEventSender::new(EVENT_CHANNEL_SIZE, 1);
+    let _raw_rx = event_tx.subscribe();
+    let input_rx = event_tx.application_subscribe();
     let (mut output_rx, handle) =
         NetEventBuffer::setup_with_limits(&bus, &input_rx, 1, DEFAULT_MAX_BUFFERED_NET_BYTES);
 
@@ -196,15 +200,10 @@ async fn sync_control_flood_does_not_consume_the_application_buffer() -> Result<
         .iter()
         .all(|event| !event.requires_application_delivery()));
 
-    let producer = actix::spawn(async move {
-        for index in 0..CONTROL_EVENTS {
-            input_tx.send(control_events[index % control_events.len()].clone())?;
-            tokio::task::yield_now().await;
-        }
-        anyhow::Ok(input_tx)
-    });
-    let input_tx = producer.await??;
-    input_tx.send(NetEvent::GossipData(GossipData::GossipBytes(vec![7])))?;
+    for index in 0..CONTROL_EVENTS {
+        event_tx.send(control_events[index % control_events.len()].clone())?;
+    }
+    event_tx.send(NetEvent::GossipData(GossipData::GossipBytes(vec![7])))?;
     bus.publish_without_context(SyncEnded::new())?;
 
     handle.wait_until_running().await?;

--- a/crates/net/src/events.rs
+++ b/crates/net/src/events.rs
@@ -331,16 +331,25 @@ impl NetEvent {
     /// Historical-sync and connection-control events use the raw network receiver and must not
     /// also occupy the startup application buffer.
     pub(crate) fn requires_application_delivery(&self) -> bool {
-        matches!(
-            self,
+        // Keep this match exhaustive. Each new event must select one delivery path.
+        match self {
             Self::GossipData(_)
-                | Self::GossipPublishError { .. }
-                | Self::GossipPublished { .. }
-                | Self::DhtGetRecordSucceeded { .. }
-                | Self::DhtPutRecordSucceeded { .. }
-                | Self::DhtGetRecordError { .. }
-                | Self::DhtPutRecordError { .. }
-        )
+            | Self::GossipPublishError { .. }
+            | Self::GossipPublished { .. }
+            | Self::DhtGetRecordSucceeded { .. }
+            | Self::DhtPutRecordSucceeded { .. }
+            | Self::DhtGetRecordError { .. }
+            | Self::DhtPutRecordError { .. } => true,
+            Self::DialError { .. }
+            | Self::ConnectionEstablished { .. }
+            | Self::PeerRejected { .. }
+            | Self::OutgoingConnectionError { .. }
+            | Self::GossipSubscribed { .. }
+            | Self::IncomingRequest(_)
+            | Self::OutgoingRequestSucceeded(_)
+            | Self::OutgoingRequestFailed(_)
+            | Self::AllPeersDialed { .. } => false,
+        }
     }
 
     /// Conservative size used by the bounded startup buffer.

--- a/crates/net/src/events.rs
+++ b/crates/net/src/events.rs
@@ -326,6 +326,23 @@ pub enum PutOrStoreError {
 }
 
 impl NetEvent {
+    /// Whether post-sync application consumers need this event.
+    ///
+    /// Historical-sync and connection-control events use the raw network receiver and must not
+    /// also occupy the startup application buffer.
+    pub(crate) fn requires_application_delivery(&self) -> bool {
+        matches!(
+            self,
+            Self::GossipData(_)
+                | Self::GossipPublishError { .. }
+                | Self::GossipPublished { .. }
+                | Self::DhtGetRecordSucceeded { .. }
+                | Self::DhtPutRecordSucceeded { .. }
+                | Self::DhtGetRecordError { .. }
+                | Self::DhtPutRecordError { .. }
+        )
+    }
+
     /// Conservative size used by the bounded startup buffer.
     ///
     /// The enum's inline storage is always counted. Heap-backed protocol payloads that can be

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -61,8 +61,15 @@ pub fn setup_net_interface(
     keypair: Libp2pKeypair,
     peers: Vec<String>,
     quic_port: u16,
+    max_buffered_events: usize,
 ) -> Result<NetInterfaceHandle> {
-    let mut interface = Libp2pNetInterface::new(keypair, peers, Some(quic_port), network)?;
+    let mut interface = Libp2pNetInterface::new_with_application_event_capacity(
+        keypair,
+        peers,
+        Some(quic_port),
+        network,
+        max_buffered_events,
+    )?;
 
     let handle = interface.handle();
 
@@ -119,11 +126,11 @@ pub fn setup_net_with_limits(
         network.clone(),
     );
 
-    // Buffer application events until SyncEnded. The sync manager consumes control events from
-    // its raw receiver.
+    // Buffer application events until SyncEnded. The producer keeps control events on the raw
+    // channel that the sync manager consumes.
     let (rx, buffer_handle) = NetEventBuffer::setup_with_limits(
         &bus,
-        &interface.rx(),
+        &interface.application_rx(),
         max_buffered_events,
         max_buffered_bytes,
     );

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -119,7 +119,8 @@ pub fn setup_net_with_limits(
         network.clone(),
     );
 
-    // Buffer all incoming events until SyncEnded
+    // Buffer application events until SyncEnded. The sync manager consumes control events from
+    // its raw receiver.
     let (rx, buffer_handle) = NetEventBuffer::setup_with_limits(
         &bus,
         &interface.rx(),

--- a/crates/net/src/net_interface.rs
+++ b/crates/net/src/net_interface.rs
@@ -22,7 +22,7 @@ use crate::{
     },
     events::{IncomingResponse, OutgoingRequest, ProtocolResponse},
     keypair::Libp2pKeypair,
-    net_interface_handle::NetInterfaceHandle,
+    net_interface_handle::{NetEventSender, NetInterfaceHandle},
     peer_admission::PeerAdmission,
     NetworkPolicy, NetworkStatus,
 };
@@ -57,11 +57,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use tokio::{
-    select,
-    sync::{broadcast, mpsc},
-    time::MissedTickBehavior,
-};
+use tokio::{select, sync::mpsc, time::MissedTickBehavior};
 use tracing::{debug, error, info, trace, warn};
 
 const MAX_KADEMLIA_PAYLOAD_BYTES: usize = 26 * 1024 * 1024;
@@ -71,8 +67,9 @@ const DHT_MAX_TTL: Duration = Duration::from_secs(31 * 24 * 60 * 60);
 const DHT_MAX_PROVIDERS_PER_KEY: usize = 20;
 const MAX_CONSECUTIVE_DIAL_FAILURES: u32 = 3;
 const STALE_PEER_COOLDOWN: Duration = Duration::from_secs(30 * 60);
-const EVENT_CHANNEL_SIZE: usize = 1000;
+pub(crate) const EVENT_CHANNEL_SIZE: usize = 1000;
 const CMD_CHANNEL_SIZE: usize = 1000;
+const LIBP2P_ESTABLISHED_PER_PEER_LIMIT_TEXT: &str = "established connections per peer";
 
 type GossipBehaviour =
     gossipsub::Behaviour<gossipsub::IdentityTransform, gossipsub::WhitelistSubscriptionFilter>;
@@ -185,9 +182,11 @@ fn is_redundant_peer_connection_denial(error: &ListenError) -> bool {
     let mut current: &(dyn std::error::Error + 'static) = cause;
     loop {
         if let Some(exceeded) = current.downcast_ref::<connection_limits::Exceeded>() {
+            // libp2p-connection-limits 0.6.0 keeps the limit kind private. Cargo.lock pins this
+            // dependency, and the regression test verifies its per-peer display text.
             return exceeded
                 .to_string()
-                .contains("established connections per peer");
+                .contains(LIBP2P_ESTABLISHED_PER_PEER_LIMIT_TEXT);
         }
         let Some(source) = current.source() else {
             return false;
@@ -217,8 +216,8 @@ pub struct Libp2pNetInterface {
     udp_port: Option<u16>,
     /// The gossipsub topic that the peer should listen on
     topic: gossipsub::IdentTopic,
-    /// Broadcast channel to report NetEvents to listeners
-    event_tx: broadcast::Sender<NetEvent>,
+    /// Routes NetEvents to the raw and application channels.
+    event_tx: NetEventSender,
     /// Transmission channel to send NetCommands to the Libp2pNetInterface
     cmd_tx: mpsc::Sender<NetCommand>,
     /// Local receiver to process NetCommands from
@@ -236,7 +235,26 @@ impl Libp2pNetInterface {
         udp_port: Option<u16>,
         network: NetworkPolicy,
     ) -> Result<Self> {
-        let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_SIZE);
+        Self::new_with_application_event_capacity(
+            id,
+            peers,
+            udp_port,
+            network,
+            crate::DEFAULT_MAX_BUFFERED_NET_EVENTS,
+        )
+    }
+
+    pub(crate) fn new_with_application_event_capacity(
+        id: Libp2pKeypair,
+        peers: Vec<String>,
+        udp_port: Option<u16>,
+        network: NetworkPolicy,
+        application_event_capacity: usize,
+    ) -> Result<Self> {
+        if application_event_capacity == 0 {
+            bail!("application event channel capacity must be greater than zero");
+        }
+        let event_tx = NetEventSender::new(EVENT_CHANNEL_SIZE, application_event_capacity);
         let (cmd_tx, cmd_rx) = mpsc::channel(CMD_CHANNEL_SIZE);
         let status = NetworkStatus::new(peers.len());
 
@@ -267,6 +285,7 @@ impl Libp2pNetInterface {
         NetInterfaceHandle::new(
             self.cmd_tx.clone(),
             self.event_tx.subscribe(),
+            self.event_tx.application_subscribe(),
             self.status.clone(),
         )
     }
@@ -497,7 +516,7 @@ fn create_behaviour(
 /// Process all swarm events
 async fn process_swarm_event(
     swarm: &mut Swarm<NodeBehaviour>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     cmd_tx: &mpsc::Sender<NetCommand>,
     correlator: &mut Correlator,
     peer_failures: &mut PeerConnectionFailures,
@@ -1110,7 +1129,7 @@ async fn process_swarm_event(
 /// Process all swarm commands except shutdown.
 async fn process_swarm_command(
     swarm: &mut Swarm<NodeBehaviour>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     correlator: &mut Correlator,
     peer_admission: &PeerAdmission,
     network: &NetworkPolicy,
@@ -1190,7 +1209,7 @@ async fn process_swarm_command(
 
 fn handle_gossip_publish(
     swarm: &mut Swarm<NodeBehaviour>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     network: &NetworkPolicy,
     data: GossipData,
     topic: String,
@@ -1234,7 +1253,7 @@ fn handle_gossip_publish(
 
 fn handle_dial(
     swarm: &mut Swarm<NodeBehaviour>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     dial_opts: DialOpts,
 ) -> Result<()> {
     trace!("DIAL: {:?}", dial_opts);
@@ -1307,7 +1326,7 @@ fn prune_dht_peer_quotas(
 
 fn handle_put_record(
     swarm: &mut Swarm<NodeBehaviour>,
-    event_tx: &broadcast::Sender<NetEvent>,
+    event_tx: &NetEventSender,
     correlator: &mut Correlator,
     correlation_id: CorrelationId,
     key: ContentHash,
@@ -1527,11 +1546,33 @@ mod tests {
             Err(error) => error,
             Ok(_) => panic!("a zero per-peer connection limit must reject the connection"),
         };
+        let exceeded = limit_error
+            .downcast_ref::<libp2p::connection_limits::Exceeded>()
+            .expect("the connection-limits behaviour must return Exceeded");
+        assert_eq!(
+            exceeded.to_string(),
+            "connection limit exceeded: at most 0 established connections per peer are allowed"
+        );
         let error = ListenError::Denied {
             cause: ConnectionDenied::new(limit_error),
         };
 
         assert!(super::is_redundant_peer_connection_denial(&error));
+    }
+
+    #[test]
+    fn other_connection_limit_denial_is_not_redundant() {
+        let mut behaviour =
+            Behaviour::new(ConnectionLimits::default().with_max_pending_incoming(Some(0)));
+        let address: Multiaddr = "/memory/1".parse().unwrap();
+        let limit_error = behaviour
+            .handle_pending_inbound_connection(ConnectionId::new_unchecked(1), &address, &address)
+            .expect_err("a zero pending-incoming limit must reject the connection");
+        let error = ListenError::Denied {
+            cause: ConnectionDenied::new(limit_error),
+        };
+
+        assert!(!super::is_redundant_peer_connection_denial(&error));
     }
 
     #[test]

--- a/crates/net/src/net_interface.rs
+++ b/crates/net/src/net_interface.rs
@@ -46,7 +46,7 @@ use libp2p::{
         self, cbor, Event as RequestResponseEvent, Message as RequestResponseMessage,
         ProtocolSupport,
     },
-    swarm::{dial_opts::DialOpts, DialError, NetworkBehaviour, SwarmEvent},
+    swarm::{dial_opts::DialOpts, DialError, ListenError, NetworkBehaviour, SwarmEvent},
     Multiaddr, Swarm,
 };
 use rand::prelude::IteratorRandom;
@@ -176,6 +176,24 @@ fn is_unspecified_addr(addr: &Multiaddr) -> bool {
         Protocol::Ip6(ip) => ip.is_unspecified(),
         _ => false,
     })
+}
+
+fn is_redundant_peer_connection_denial(error: &ListenError) -> bool {
+    let ListenError::Denied { cause } = error else {
+        return false;
+    };
+    let mut current: &(dyn std::error::Error + 'static) = cause;
+    loop {
+        if let Some(exceeded) = current.downcast_ref::<connection_limits::Exceeded>() {
+            return exceeded
+                .to_string()
+                .contains("established connections per peer");
+        }
+        let Some(source) = current.source() else {
+            return false;
+        };
+        current = source;
+    }
 }
 
 #[derive(NetworkBehaviour)]
@@ -623,12 +641,17 @@ async fn process_swarm_event(
         }
 
         SwarmEvent::IncomingConnectionError { error, .. } => {
+            let is_redundant_connection = is_redundant_peer_connection_denial(&error);
             let error_str = format!("{:#}", anyhow::Error::from(error));
             // Downgrade benign handshake failures to debug:
             // - "Local peer ID": self-dial attempt
             // - "aborted by peer": simultaneous connection dedup (both sides dialed,
             //   libp2p keeps one connection and the other side aborts the handshake)
-            if error_str.contains("Local peer ID") || error_str.contains("aborted by peer") {
+            // - connection-limit denial: an existing peer opened a redundant connection
+            if is_redundant_connection
+                || error_str.contains("Local peer ID")
+                || error_str.contains("aborted by peer")
+            {
                 debug!("{}", error_str);
             } else {
                 status.record_error(format!("incoming connection: {error_str}"));
@@ -1438,9 +1461,11 @@ fn handle_response(swarm: &mut Swarm<NodeBehaviour>, responder: DirectResponder)
 
 #[cfg(test)]
 mod tests {
+    use libp2p::connection_limits::{Behaviour, ConnectionLimits};
     use libp2p::kad::store::{MemoryStore, MemoryStoreConfig, RecordStore};
     use libp2p::kad::{Record, RecordKey};
-    use libp2p::PeerId;
+    use libp2p::swarm::{ConnectionDenied, ConnectionId, ListenError, NetworkBehaviour};
+    use libp2p::{Multiaddr, PeerId};
     use std::time::{Duration, Instant};
 
     #[test]
@@ -1486,6 +1511,27 @@ mod tests {
         );
         // Idempotent on addresses without a /p2p/ suffix
         assert_eq!(super::strip_peer_id(stripped.clone()), stripped);
+    }
+
+    #[test]
+    fn nested_per_peer_connection_limit_denial_is_expected() {
+        let mut behaviour =
+            Behaviour::new(ConnectionLimits::default().with_max_established_per_peer(Some(0)));
+        let address: Multiaddr = "/memory/1".parse().unwrap();
+        let limit_error = match behaviour.handle_established_inbound_connection(
+            ConnectionId::new_unchecked(1),
+            PeerId::random(),
+            &address,
+            &address,
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("a zero per-peer connection limit must reject the connection"),
+        };
+        let error = ListenError::Denied {
+            cause: ConnectionDenied::new(limit_error),
+        };
+
+        assert!(super::is_redundant_peer_connection_denial(&error));
     }
 
     #[test]

--- a/crates/net/src/net_interface_handle.rs
+++ b/crates/net/src/net_interface_handle.rs
@@ -16,19 +16,70 @@ use crate::{
     NetworkStatus,
 };
 
+/// Sends each network event to the raw channel and, when required, to the application channel.
+///
+/// The application channel excludes sync and connection-control traffic at the producer.
+#[derive(Debug, Clone)]
+pub struct NetEventSender {
+    raw: broadcast::Sender<NetEvent>,
+    application: broadcast::Sender<NetEvent>,
+}
+
+impl NetEventSender {
+    pub(crate) fn new(raw_capacity: usize, application_capacity: usize) -> Self {
+        let (raw, _) = broadcast::channel(raw_capacity);
+        let (application, _) = broadcast::channel(application_capacity);
+        Self { raw, application }
+    }
+
+    /// Sends one event to its required channels.
+    pub fn send(&self, event: NetEvent) -> Result<usize, broadcast::error::SendError<NetEvent>> {
+        if !event.requires_application_delivery() {
+            return self.raw.send(event);
+        }
+
+        let raw_result = self.raw.send(event.clone());
+        let application_result = self.application.send(event);
+
+        match (raw_result, application_result) {
+            (Ok(receivers), _) | (Err(_), Ok(receivers)) => Ok(receivers),
+            (Err(error), Err(_)) => Err(error),
+        }
+    }
+
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<NetEvent> {
+        self.raw.subscribe()
+    }
+
+    pub(crate) fn application_subscribe(&self) -> broadcast::Receiver<NetEvent> {
+        self.application.subscribe()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.raw.len()
+    }
+}
+
 #[derive(Debug)]
 pub struct NetInterfaceHandle {
     tx: mpsc::Sender<NetCommand>,
     rx: broadcast::Receiver<NetEvent>,
+    application_rx: broadcast::Receiver<NetEvent>,
     status: NetworkStatus,
 }
 impl NetInterfaceHandle {
-    pub fn new(
+    pub(crate) fn new(
         tx: mpsc::Sender<NetCommand>,
         rx: broadcast::Receiver<NetEvent>,
+        application_rx: broadcast::Receiver<NetEvent>,
         status: NetworkStatus,
     ) -> Self {
-        Self { tx, rx, status }
+        Self {
+            tx,
+            rx,
+            application_rx,
+            status,
+        }
     }
 
     pub fn status(&self) -> NetworkStatus {
@@ -39,6 +90,8 @@ impl NetInterfaceHandle {
 pub trait NetInterface: Sized {
     fn tx(&self) -> mpsc::Sender<NetCommand>;
     fn rx(&self) -> broadcast::Receiver<NetEvent>;
+    /// Returns a receiver that contains only application-delivery events.
+    fn application_rx(&self) -> broadcast::Receiver<NetEvent>;
     fn status(&self) -> NetworkStatus;
     fn handle(&self) -> NetInterfaceHandle {
         NetInterfaceHandle::from(self)
@@ -51,7 +104,7 @@ pub trait NetInterface: Sized {
 pub struct NetChannelBridge {
     cmd_tx: broadcast::Sender<NetCommand>,
     tx: mpsc::Sender<NetCommand>,
-    event_tx: broadcast::Sender<NetEvent>,
+    event_tx: NetEventSender,
 }
 
 impl NetInterfaceHandle {
@@ -59,6 +112,7 @@ impl NetInterfaceHandle {
         Self {
             tx: interface.tx(),
             rx: interface.rx(),
+            application_rx: interface.application_rx(),
             status: interface.status(),
         }
     }
@@ -72,6 +126,10 @@ impl NetInterface for NetInterfaceHandle {
         self.tx.clone()
     }
 
+    fn application_rx(&self) -> broadcast::Receiver<NetEvent> {
+        self.application_rx.resubscribe()
+    }
+
     fn status(&self) -> NetworkStatus {
         self.status.clone()
     }
@@ -79,12 +137,23 @@ impl NetInterface for NetInterfaceHandle {
 
 /// This creates a channel bridge which allows for network events to be connected between test nodes
 pub fn create_channel_bridge() -> (NetInterfaceHandle, NetChannelBridge) {
+    create_channel_bridge_with_application_event_capacity(crate::DEFAULT_MAX_BUFFERED_NET_EVENTS)
+}
+
+/// Creates a test channel bridge whose application channel uses the specified capacity.
+pub fn create_channel_bridge_with_application_event_capacity(
+    application_event_capacity: usize,
+) -> (NetInterfaceHandle, NetChannelBridge) {
+    assert!(
+        application_event_capacity > 0,
+        "application event channel capacity must be greater than zero"
+    );
     let (m_cmd_tx, mut m_cmd_rx) = mpsc::channel::<NetCommand>(1000);
-    let (b_evt_tx, _) = broadcast::channel(1000);
+    let event_tx = NetEventSender::new(1000, application_event_capacity);
     let (b_cmd_tx, _) = broadcast::channel(1000);
 
     let tx = b_cmd_tx.clone();
-    let startup_event_tx = b_evt_tx.clone();
+    let startup_event_tx = event_tx.clone();
     let keep_alive = b_cmd_tx.subscribe();
 
     // Bridge from mpsc channel to broadcast channel simulating AllPeersDialed for each node
@@ -102,14 +171,15 @@ pub fn create_channel_bridge() -> (NetInterfaceHandle, NetChannelBridge) {
 
     let handle = NetInterfaceHandle {
         tx: m_cmd_tx.clone(),
-        rx: b_evt_tx.subscribe(),
+        rx: event_tx.subscribe(),
+        application_rx: event_tx.application_subscribe(),
         status: NetworkStatus::new(0),
     };
 
     let inverted = NetChannelBridge {
         tx: m_cmd_tx,
         cmd_tx: b_cmd_tx,
-        event_tx: b_evt_tx,
+        event_tx,
     };
 
     (handle, inverted)
@@ -117,7 +187,7 @@ pub fn create_channel_bridge() -> (NetInterfaceHandle, NetChannelBridge) {
 
 pub trait NetInterfaceInverted: Sized {
     fn tx(&self) -> mpsc::Sender<NetCommand>;
-    fn event_tx(&self) -> broadcast::Sender<NetEvent>; //U
+    fn event_tx(&self) -> NetEventSender; //U
     fn event_rx(&self) -> broadcast::Receiver<NetEvent>;
     fn cmd_tx(&self) -> broadcast::Sender<NetCommand>;
     fn cmd_rx(&self) -> broadcast::Receiver<NetCommand>; //U
@@ -139,7 +209,7 @@ impl NetInterfaceInverted for NetChannelBridge {
     fn cmd_rx(&self) -> broadcast::Receiver<NetCommand> {
         self.cmd_tx.subscribe()
     }
-    fn event_tx(&self) -> broadcast::Sender<NetEvent> {
+    fn event_tx(&self) -> NetEventSender {
         self.event_tx.clone()
     }
     fn cmd_tx(&self) -> broadcast::Sender<NetCommand> {
@@ -147,5 +217,32 @@ impl NetInterfaceInverted for NetChannelBridge {
     }
     fn event_rx(&self) -> broadcast::Receiver<NetEvent> {
         self.event_tx.subscribe()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::events::GossipData;
+
+    use super::*;
+
+    #[test]
+    fn application_event_send_succeeds_with_either_channel_subscribed() {
+        let raw_only = NetEventSender::new(1, 1);
+        let mut raw_rx = raw_only.subscribe();
+        raw_only
+            .send(NetEvent::GossipData(GossipData::GossipBytes(vec![1])))
+            .expect("raw delivery must succeed without an application subscriber");
+        assert!(matches!(raw_rx.try_recv(), Ok(NetEvent::GossipData(_))));
+
+        let application_only = NetEventSender::new(1, 1);
+        let mut application_rx = application_only.application_subscribe();
+        application_only
+            .send(NetEvent::GossipData(GossipData::GossipBytes(vec![2])))
+            .expect("application delivery must succeed without a raw subscriber");
+        assert!(matches!(
+            application_rx.try_recv(),
+            Ok(NetEvent::GossipData(_))
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- Keep historical-sync and connection-control NetEvents on the raw receiver without admitting them to the startup application buffer.
- Preserve count and byte limits for gossip, publish-result, and DHT events that application consumers need after sync.
- Keep the two-connections-per-peer limit, but classify its expected redundant-connection denial at debug level without marking network health as failed. Other connection-limit errors remain warnings.
- Update the internal network and restart architecture trace.

## Production impact

A large historical sync can no longer fill the 1,024-event application buffer with request/response control traffic. Nodes retain their database and fail-closed protection for actual live application backlog.

## Verification

- cargo test -p e3-net: 101 unit tests, network isolation, peer-ID recovery, and doc tests passed.
- A focused regression passed with 100,000 historical-sync response events and a one-event application buffer.
- The nested libp2p per-peer connection-limit regression passed.
- pnpm test:integration net --no-prebuild passed for all six peers.
- cargo fmt, doc sync, invariant, committee, license, and repository lint checks passed.

The local pre-push verifier check could not run because nargo is not installed. This change does not modify circuits or verifiers; CI remains authoritative for that check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented network control and historical-sync events from consuming application event buffer capacity during startup.
  * Ensured application events continue to be delivered correctly after synchronization completes.
  * Improved handling and diagnostic logging of connection denials caused by per-peer connection limits.
* **Tests**
  * Added coverage confirming control-event floods do not block application events.
  * Added validation for nested connection-limit denial errors and event delivery across network channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->