### PR TITLE
fix(support): request Groth16 Boundless proofs

### DIFF
--- a/crates/support/host/src/lib.rs
+++ b/crates/support/host/src/lib.rs
@@ -282,6 +282,8 @@ async fn boundless_prove_inner(
             .with_offer(build_offer()?)
     };
 
+    let request = request.with_groth16_proof();
+
     let onchain =
         std::env::var("BOUNDLESS_ONCHAIN").unwrap_or_else(|_| "true".to_string()) == "true";
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.91.1"
-components = ["rustfmt"]
+components = ["rustfmt", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## What

Request Groth16 proofs for Boundless jobs so the returned seal is compatible with the RISC Zero Groth16 verifier. Install rust-analyzer through the pinned Rust toolchain for consistent editor setup.

## Checklist

- [x] **Verified at the smallest covering scope** — pre-push lint, license, committee, documentation, invariant, and verifier checks passed. rust-analyzer --version reports 1.91.1.
- [x] **Harness docs** — this change does not change the documented protocol flow or CLI behavior.
- [x] **Invariants** — the diff does not change committee ordering, thresholds, proof multiplicity, hashing, signatures, witness shape, event identity, or replay behavior.
- [x] **Known bugs table** — this change does not fix or introduce a listed protocol concern.
- [x] **Breaking?** — no.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Requests now explicitly require Groth16 proofs before submission, improving proof verification consistency.
  * Added Rust Analyzer to the development toolchain for improved code assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->