### PR TITLE
fix(support): publish and pull matching images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1161,6 +1161,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           submodules: recursive
+      - name: Test support image resolution
+        run: bash crates/support-scripts/tests/container.sh
       - name: Cache Rust dependencies
         uses: ./.github/actions/cache-dependencies
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -163,6 +163,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve the CLI revision tag
+        id: revision
+        run: echo "short_sha=$(git rev-parse --short=9 HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build & push e3-support release image
         uses: docker/build-push-action@v5
         with:
@@ -171,6 +175,7 @@ jobs:
           push: true
           tags: |
             ${{ env.SUPPORT_IMAGE_NAME }}:${{ needs.validate-and-prepare.outputs.version }}
+            ${{ env.SUPPORT_IMAGE_NAME }}:${{ steps.revision.outputs.short_sha }}
             ${{ env.SUPPORT_IMAGE_NAME }}:latest
           cache-from: |
             type=gha,scope=e3-support
@@ -229,7 +234,7 @@ jobs:
   build-binaries:
     name: Build Binaries (${{ matrix.os_name }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
-    needs: validate-and-prepare
+    needs: [validate-and-prepare, build-e3-support-release]
     strategy:
       matrix:
         include:
@@ -304,7 +309,7 @@ jobs:
   publish-rust-crates:
     name: Publish Rust Crates
     runs-on: ubuntu-latest
-    needs: validate-and-prepare
+    needs: [validate-and-prepare, build-e3-support-release]
     continue-on-error: true
     # Publish ALL versions to crates.io (including pre-releases)
     steps:
@@ -513,7 +518,8 @@ jobs:
       ]
     if:
       always() && needs.validate-and-prepare.result == 'success' && needs.build-binaries.result == 'success' &&
-      (needs.validate-and-prepare.outputs.is_prerelease == 'true' || needs.build-dappnode-package-release.result == 'success')
+      needs.build-e3-support-release.result == 'success' && (needs.validate-and-prepare.outputs.is_prerelease == 'true' ||
+      needs.build-dappnode-package-release.result == 'success')
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/crates/support-scripts/ctl/container
+++ b/crates/support-scripts/ctl/container
@@ -2,17 +2,19 @@
 
 GIT_SHA=$(interfold rev)
 CONTAINER_NAME="e3-support.1"
-IMAGE="ghcr.io/gnosisguild/e3-support:$GIT_SHA"
+IMAGE_REPOSITORY="${E3_SUPPORT_IMAGE_REPOSITORY:-ghcr.io/theinterfold/e3-support}"
+IMAGE="$IMAGE_REPOSITORY:$GIT_SHA"
 CACHE_PREFIX="e3-support"
 
-# Check if the image exists locally or remotely if not bail
-# Every time we push we build support so every build of interfold should have support built too.
-# This solves the problem where a person will be using the cli with a specific `interfold rev` but our latest 
-# support scripts have changed which will break the support behaviour for the user.
-# The user can then upgrade their cli once they are ready and then the support image will match their version
-if ! docker image inspect "$IMAGE" >/dev/null 2>&1 && ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-    echo "Support scripts not found for git sha \"$GIT_SHA\" Please recompile the support scripts for this version of the interfold cli within the source repository"
-    exit 1
+# Use the support image that matches the CLI revision.
+# This match prevents incompatible support script changes after a CLI update.
+# Pull the image only when the image is not available locally.
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "Support image not found locally. Pulling $IMAGE..."
+    if ! docker pull "$IMAGE"; then
+        echo "Support image $IMAGE is unavailable. Verify the image tag and registry access."
+        exit 1
+    fi
 fi
 
 # Function to cleanup

--- a/crates/support-scripts/tests/container.sh
+++ b/crates/support-scripts/tests/container.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPOSITORY_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+START_SCRIPT="$REPOSITORY_ROOT/crates/support-scripts/ctl/start"
+TEST_REVISION="abc123456"
+TEST_PARENT="${TMPDIR:-/tmp}"
+TEST_PARENT="${TEST_PARENT%/}"
+TEST_DIRECTORIES=()
+
+cleanup() {
+  local directory
+  for directory in "${TEST_DIRECTORIES[@]}"; do
+    case "$directory" in
+      "$TEST_PARENT"/e3-support-test.*) rm -rf -- "$directory" ;;
+      *)
+        echo "Refusing to remove unexpected test directory: $directory" >&2
+        return 1
+        ;;
+    esac
+  done
+}
+trap cleanup EXIT
+
+interfold() {
+  if [[ "${1:-}" != "rev" ]]; then
+    return 1
+  fi
+  printf '%s\n' "$TEST_REVISION"
+}
+
+docker() {
+  if [[ "${1:-}" == "image" && "${2:-}" == "inspect" ]]; then
+    return "${LOCAL_IMAGE_STATUS:-0}"
+  fi
+  if [[ "${1:-}" == "pull" ]]; then
+    printf 'DOCKER_PULL %s\n' "$2"
+    return "${PULL_STATUS:-0}"
+  fi
+  if [[ "${1:-}" == "ps" ]]; then
+    return 0
+  fi
+  if [[ "${1:-}" == "run" ]]; then
+    printf 'DOCKER_RUN %s\n' "$*"
+    return 0
+  fi
+  if [[ "${1:-}" == "exec" || "${1:-}" == "stop" ]]; then
+    return 0
+  fi
+  echo "Unexpected docker command: $*" >&2
+  return 1
+}
+
+sleep() {
+  return 0
+}
+
+export TEST_REVISION
+export -f interfold docker sleep
+
+CASE_OUTPUT=""
+CASE_STATUS=0
+
+run_case() {
+  local local_image_status="$1"
+  local pull_status="$2"
+  local image_repository="${3:-}"
+  local directory
+
+  directory=$(mktemp -d "$TEST_PARENT/e3-support-test.XXXXXX")
+  TEST_DIRECTORIES+=("$directory")
+
+  set +e
+  CASE_OUTPUT=$(
+    cd "$directory" || exit 1
+    export LOCAL_IMAGE_STATUS="$local_image_status"
+    export PULL_STATUS="$pull_status"
+    if [[ -n "$image_repository" ]]; then
+      export E3_SUPPORT_IMAGE_REPOSITORY="$image_repository"
+    else
+      unset E3_SUPPORT_IMAGE_REPOSITORY
+    fi
+    bash "$START_SCRIPT" --risc0-dev-mode false 2>&1
+  )
+  CASE_STATUS=$?
+  set -e
+}
+
+assert_contains() {
+  local expected="$1"
+  if [[ "$CASE_OUTPUT" != *"$expected"* ]]; then
+    echo "Expected output to contain: $expected" >&2
+    echo "$CASE_OUTPUT" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local unexpected="$1"
+  if [[ "$CASE_OUTPUT" == *"$unexpected"* ]]; then
+    echo "Expected output not to contain: $unexpected" >&2
+    echo "$CASE_OUTPUT" >&2
+    exit 1
+  fi
+}
+
+run_case 0 0
+[[ "$CASE_STATUS" -eq 0 ]]
+assert_not_contains "DOCKER_PULL"
+assert_contains "DOCKER_RUN"
+assert_contains "ghcr.io/theinterfold/e3-support:$TEST_REVISION"
+
+run_case 1 0
+[[ "$CASE_STATUS" -eq 0 ]]
+assert_contains "DOCKER_PULL ghcr.io/theinterfold/e3-support:$TEST_REVISION"
+assert_contains "DOCKER_RUN"
+
+run_case 1 1
+[[ "$CASE_STATUS" -ne 0 ]]
+assert_contains "Support image ghcr.io/theinterfold/e3-support:$TEST_REVISION is unavailable"
+assert_not_contains "DOCKER_RUN"
+
+run_case 0 0 "registry.example/e3-support"
+[[ "$CASE_STATUS" -eq 0 ]]
+assert_contains "registry.example/e3-support:$TEST_REVISION"
+
+echo "Support image container tests passed."

--- a/crates/support/README.md
+++ b/crates/support/README.md
@@ -290,7 +290,15 @@ boundless:
 ./scripts/build.sh --push
 ```
 
-The container is also built by the GitHub workflow at `.github/workflows/support-docker.yml`.
+The CI workflow builds the container for applicable pull requests without publishing it. A manual CI
+run on `main` publishes the nine-character commit tag and the `main` tag.
+
+Each release publishes the version tag, the nine-character commit tag, and the `latest` tag. The CLI
+uses its embedded commit tag. The CLI pulls the matching image when the image is not available
+locally.
+
+Set `E3_SUPPORT_IMAGE_REPOSITORY` to use an authorized mirror instead of the default GitHub
+Container Registry repository.
 
 ## Development
 

--- a/crates/support/scripts/build.sh
+++ b/crates/support/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-PKG=ghcr.io/gnosisguild/e3-support
+PKG="${E3_SUPPORT_IMAGE_REPOSITORY:-ghcr.io/theinterfold/e3-support}"
 GIT_SHA=$(git rev-parse --short=9 HEAD)
 
 # Separate --push from other arguments
@@ -15,10 +15,10 @@ for arg in "$@"; do
 done
 
 # Build with any additional arguments
-docker build -t $PKG:$GIT_SHA "${BUILD_ARGS[@]}" .
+docker build -t "$PKG:$GIT_SHA" "${BUILD_ARGS[@]}" .
 
 # Push if --push was specified
 if [ "$PUSH" = true ]; then
-  docker push $PKG:$GIT_SHA
+  docker push "$PKG:$GIT_SHA"
   echo "Image pushed to: $PKG:$GIT_SHA"
 fi

--- a/crates/support/scripts/dev.sh
+++ b/crates/support/scripts/dev.sh
@@ -1,15 +1,16 @@
-# dev
-PKG=ghcr.io/gnosisguild/e3-support:next
+#!/usr/bin/env bash
+
+PKG="${E3_SUPPORT_IMAGE_REPOSITORY:-ghcr.io/theinterfold/e3-support}:next"
 
 docker run -it \
-  -v $(pwd)/app:/app/app \
-  -v $(pwd)/host:/app/host \
-  -v $(pwd)/methods:/app/methods \
-  -v $(pwd)/types:/app/types \
-  -v $(pwd)/program:/app/program \
-  -v $(pwd)/scripts:/app/scripts \
-  -v $(pwd)/.interfold/generated/contracts:/app/contracts \
-  -v $(pwd)/.interfold/generated/tests:/app/tests \
-  -v $(pwd)/Cargo.toml:/app/Cargo.toml \
-  -v $(pwd)/Cargo.lock:/app/Cargo.lock \
-  $PKG
+  -v "$(pwd)/app:/app/app" \
+  -v "$(pwd)/host:/app/host" \
+  -v "$(pwd)/methods:/app/methods" \
+  -v "$(pwd)/types:/app/types" \
+  -v "$(pwd)/program:/app/program" \
+  -v "$(pwd)/scripts:/app/scripts" \
+  -v "$(pwd)/.interfold/generated/contracts:/app/contracts" \
+  -v "$(pwd)/.interfold/generated/tests:/app/tests" \
+  -v "$(pwd)/Cargo.toml:/app/Cargo.toml" \
+  -v "$(pwd)/Cargo.lock:/app/Cargo.lock" \
+  "$PKG"


### PR DESCRIPTION
## Summary

- publish each e3-support release image with the CLI revision tag
- publish the matching support image before CLI binaries and Rust crates
- pull the matching image when it is not available locally
- use the current GHCR namespace and support an authorized mirror
- test local, pull, failure, and mirror behavior

## Verification

- `bash crates/support-scripts/tests/container.sh`
- `shellcheck crates/support-scripts/ctl/container crates/support-scripts/tests/container.sh crates/support/scripts/build.sh crates/support/scripts/dev.sh`
- `actionlint` on the changed workflows
- `pnpm lint`
- `pnpm check:pnpm`
- `pnpm check:license`
- `pnpm check:committee`
- `pnpm check:docs`
- `pnpm check:invariants`
- `pnpm check:verifiers`