### PR TITLE
fix: subscriber backpressure

### DIFF
--- a/crates/net/src/direct_requester.rs
+++ b/crates/net/src/direct_requester.rs
@@ -4,7 +4,8 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-use std::{fmt, marker::PhantomData, sync::Arc, time::Duration};
+use crate::net_interface_handle::NetEventSubscriber;
+use std::{fmt, marker::PhantomData, time::Duration};
 
 use anyhow::{anyhow, Result};
 use e3_events::CorrelationId;
@@ -57,7 +58,7 @@ pub struct WithPeer(#[allow(dead_code)] PeerTarget);
 /// ```
 pub struct DirectRequester<State> {
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     request_timeout: Duration,
     max_retries: u32,
     retry_timeout: Duration,
@@ -74,7 +75,7 @@ impl DirectRequester<WithoutPeer> {
     /// - retry_timeout: 5 seconds
     pub fn builder(
         net_cmds: mpsc::Sender<NetCommand>,
-        net_events: Arc<broadcast::Receiver<NetEvent>>,
+        net_events: NetEventSubscriber,
     ) -> DirectRequesterBuilder {
         DirectRequesterBuilder {
             net_cmds: Some(net_cmds),
@@ -156,7 +157,7 @@ impl DirectRequester<WithPeer> {
 
 pub struct DirectRequesterBuilder {
     net_cmds: Option<mpsc::Sender<NetCommand>>,
-    net_events: Option<Arc<broadcast::Receiver<NetEvent>>>,
+    net_events: Option<NetEventSubscriber>,
     request_timeout: Option<Duration>,
     max_retries: Option<u32>,
     retry_timeout: Option<Duration>,
@@ -196,7 +197,7 @@ impl DirectRequesterBuilder {
 
 async fn do_request(
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     target: PeerTarget,
     payload: Vec<u8>,
     timeout: Duration,
@@ -416,8 +417,8 @@ mod tests {
     #[tokio::test]
     async fn test_successful_request() {
         let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-        let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-        let net_events = Arc::new(net_events_rx);
+        let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+        let net_events = NetEventSubscriber::from(&net_events_tx);
 
         let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 
@@ -440,8 +441,8 @@ mod tests {
     #[tokio::test]
     async fn test_request_with_peer_target() {
         let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-        let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-        let net_events = Arc::new(net_events_rx);
+        let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+        let net_events = NetEventSubscriber::from(&net_events_tx);
 
         let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 
@@ -462,8 +463,8 @@ mod tests {
     #[tokio::test]
     async fn test_peer_requester_reuse_across_requests() {
         let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-        let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-        let net_events = Arc::new(net_events_rx);
+        let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+        let net_events = NetEventSubscriber::from(&net_events_tx);
 
         let requester = DirectRequester::builder(net_cmds_tx, net_events)
             .request_timeout(Duration::from_secs(10))
@@ -490,8 +491,8 @@ mod tests {
     #[tokio::test]
     async fn test_expect_request() {
         let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-        let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-        let net_events = Arc::new(net_events_rx);
+        let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+        let net_events = NetEventSubscriber::from(&net_events_tx);
 
         let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 
@@ -516,8 +517,8 @@ mod tests {
     #[tokio::test]
     async fn test_request_failure() {
         let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-        let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-        let net_events = Arc::new(net_events_rx);
+        let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+        let net_events = NetEventSubscriber::from(&net_events_tx);
 
         let requester = DirectRequester::builder(net_cmds_tx, net_events)
             .max_retries(0)
@@ -545,8 +546,8 @@ mod tests {
     #[tokio::test]
     async fn test_respond_with_each() {
         let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-        let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-        let net_events = Arc::new(net_events_rx);
+        let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+        let net_events = NetEventSubscriber::from(&net_events_tx);
 
         let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 

--- a/crates/net/src/document_publishing/actor.rs
+++ b/crates/net/src/document_publishing/actor.rs
@@ -4,6 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
+use crate::net_interface_handle::NetEventSubscriber;
 use crate::{
     domain::{datetime_to_instant_from_now, DocumentPublishingService},
     events::{
@@ -25,8 +26,8 @@ use e3_utils::{
     MAILBOX_LIMIT,
 };
 use futures::TryFutureExt;
-use std::{collections::HashMap, sync::Arc, time::Duration};
-use tokio::sync::{broadcast, mpsc};
+use std::{collections::HashMap, time::Duration};
+use tokio::sync::mpsc;
 use tracing::{debug, info};
 
 use super::event_converter::EventConverter;
@@ -44,9 +45,8 @@ pub struct DocumentPublisher {
     bus: BusHandle,
     /// NetCommand sender to forward commands to the Libp2pNetInterface
     tx: mpsc::Sender<NetCommand>,
-    /// NetEvent receiver to resubscribe for events from the Libp2pNetInterface. This is in an Arc
-    /// so that we do not do excessive resubscribes without actually listening for events.
-    rx: Arc<broadcast::Receiver<NetEvent>>,
+    /// Subscriber used to open a fresh NetEvent receiver per publish operation.
+    rx: NetEventSubscriber,
     /// The gossipsub broadcast topic
     topic: String,
     /// Pure decision/state service.
@@ -58,7 +58,7 @@ impl DocumentPublisher {
     pub fn new(
         bus: &BusHandle,
         tx: &mpsc::Sender<NetCommand>,
-        rx: &Arc<broadcast::Receiver<NetEvent>>,
+        rx: &NetEventSubscriber,
         topic: impl Into<String>,
     ) -> Self {
         Self {
@@ -86,10 +86,10 @@ impl DocumentPublisher {
     pub fn setup(
         bus: &BusHandle,
         tx: &mpsc::Sender<NetCommand>,
-        rx: &Arc<broadcast::Receiver<NetEvent>>,
+        rx: &NetEventSubscriber,
         topic: impl Into<String>,
     ) -> Addr<Self> {
-        let mut events = rx.resubscribe();
+        let mut events = rx.subscribe();
         let addr = Self::new(bus, tx, rx, topic).start();
         EventConverter::setup(bus);
         // Listen on all events

--- a/crates/net/src/document_publishing/effects.rs
+++ b/crates/net/src/document_publishing/effects.rs
@@ -4,11 +4,12 @@
 
 use super::*;
 use crate::domain::EventConversionService;
+use crate::net_interface_handle::NetEventSubscriber;
 
 /// Called when we receive a PublishDocumentRequested event
 pub async fn handle_publish_document_requested(
     tx: mpsc::Sender<NetCommand>,
-    rx: Arc<broadcast::Receiver<NetEvent>>,
+    rx: NetEventSubscriber,
     event: PublishDocumentRequested,
     topic: impl Into<String>,
     bus: BusHandle,
@@ -37,7 +38,7 @@ pub async fn handle_publish_document_requested(
 /// Called when we receive a notification from the net_interface
 pub async fn handle_document_published_notification(
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     bus: BusHandle,
     ids: HashMap<E3id, PartyId>,
     event: DocumentPublishedNotification,
@@ -81,7 +82,7 @@ pub async fn handle_document_published_notification(
 /// Call DhtPutRecord Command on the Libp2pNetInterface and handle the results
 async fn put_record(
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     expires: Option<std::time::Instant>,
     value: ArcBytes,
     key: ContentHash,
@@ -111,7 +112,7 @@ async fn put_record(
 /// Call DhtGetRecord Command on the Libp2pNetInterface and handle the results
 async fn get_record(
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     key: ContentHash,
 ) -> Result<ArcBytes> {
     let id = CorrelationId::new();
@@ -137,7 +138,7 @@ async fn get_record(
 /// Broadcasts document published notification on Libp2pNetInterface
 async fn broadcast_document_published_notification(
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     payload: DocumentPublishedNotification,
     topic: impl Into<String>,
 ) -> Result<()> {

--- a/crates/net/src/document_publishing/tests/mod.rs
+++ b/crates/net/src/document_publishing/tests/mod.rs
@@ -4,6 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
+use crate::net_interface_handle::NetEventSubscriber;
 use std::{collections::HashMap, num::NonZero, sync::Arc, time::Duration};
 
 use super::*;
@@ -34,7 +35,7 @@ fn setup_test() -> Result<(
     mpsc::Sender<NetCommand>,
     mpsc::Receiver<NetCommand>,
     broadcast::Sender<NetEvent>,
-    Arc<broadcast::Receiver<NetEvent>>,
+    NetEventSubscriber,
     Addr<HistoryCollector<InterfoldEvent>>,
     Addr<HistoryCollector<InterfoldEvent>>,
     Addr<DocumentPublisher>,
@@ -55,8 +56,8 @@ fn setup_test() -> Result<(
         .with_aggregate_config(aggregate_config);
     let bus = system.handle()?.enable("test");
     let (net_cmd_tx, net_cmd_rx) = mpsc::channel(100);
-    let (net_evt_tx, net_evt_rx) = broadcast::channel(100);
-    let net_evt_rx = Arc::new(net_evt_rx);
+    let (net_evt_tx, _net_evt_rx) = broadcast::channel(100);
+    let net_evt_rx = NetEventSubscriber::from(&net_evt_tx);
     let history = HistoryCollector::<InterfoldEvent>::new().start();
     let error = HistoryCollector::<InterfoldEvent>::new().start();
     bus.subscribe(EventType::All, history.clone().recipient());

--- a/crates/net/src/document_publishing/tests/publishing.rs
+++ b/crates/net/src/document_publishing/tests/publishing.rs
@@ -5,6 +5,7 @@
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
 use super::*;
+use crate::net_interface_handle::NetEventSubscriber;
 
 #[actix::test]
 async fn test_publishes_document() -> Result<()> {
@@ -84,7 +85,7 @@ async fn expired_document_is_rejected_without_a_dht_write() -> Result<()> {
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle()?.enable("expired-document");
     let (net_cmd_tx, mut net_cmd_rx) = mpsc::channel(1);
-    let (_net_evt_tx, net_evt_rx) = broadcast::channel(1);
+    let (net_evt_tx, _net_evt_rx) = broadcast::channel(1);
     let event = PublishDocumentRequested {
         meta: DocumentMeta::new(
             E3id::new("expired", 1),
@@ -95,10 +96,15 @@ async fn expired_document_is_rejected_without_a_dht_write() -> Result<()> {
         value: ArcBytes::from_bytes(b"stale"),
     };
 
-    let error =
-        handle_publish_document_requested(net_cmd_tx, Arc::new(net_evt_rx), event, "topic", bus)
-            .await
-            .unwrap_err();
+    let error = handle_publish_document_requested(
+        net_cmd_tx,
+        NetEventSubscriber::from(&net_evt_tx),
+        event,
+        "topic",
+        bus,
+    )
+    .await
+    .unwrap_err();
 
     assert!(format!("{error:#}").contains("expiry is not in the future"));
     assert!(matches!(

--- a/crates/net/src/event_buffer/actor.rs
+++ b/crates/net/src/event_buffer/actor.rs
@@ -11,12 +11,14 @@ use e3_events::{
     InterfoldEventData,
 };
 use e3_utils::MAILBOX_LIMIT;
+use std::time::{Duration, Instant};
 use tokio::sync::broadcast::{self, error::RecvError};
 use tokio::sync::oneshot;
 use tracing::warn;
 
 use crate::domain::net_buffer::{BufferDecision, NetEventBufferState};
 use crate::events::NetEvent;
+use crate::net_interface_handle::NetEventSubscriber;
 
 pub const DEFAULT_MAX_BUFFERED_NET_EVENTS: usize = 1_024;
 pub const DEFAULT_MAX_BUFFERED_NET_BYTES: usize = 256 * 1024 * 1024;
@@ -45,17 +47,19 @@ pub struct NetEventBuffer {
     max_events: usize,
     max_bytes: usize,
     readiness: Option<oneshot::Sender<std::result::Result<(), String>>>,
+    last_drop_warn: Option<Instant>,
 }
 
 impl NetEventBuffer {
     pub(crate) fn setup_with_limits(
         bus: &BusHandle,
-        input_rx: &broadcast::Receiver<NetEvent>,
+        input: &NetEventSubscriber,
         max_events: usize,
         max_bytes: usize,
-    ) -> (broadcast::Receiver<NetEvent>, NetEventBufferHandle) {
-        let input_rx = input_rx.resubscribe();
-        let (output_tx, output_rx) = broadcast::channel(max_events);
+    ) -> (NetEventSubscriber, NetEventBufferHandle) {
+        let input_rx = input.subscribe();
+        let (output_tx, _) = broadcast::channel(max_events);
+        let output = NetEventSubscriber::from(&output_tx);
         let (readiness_tx, readiness) = oneshot::channel();
 
         let actor = Self {
@@ -66,6 +70,7 @@ impl NetEventBuffer {
             max_events,
             max_bytes,
             readiness: Some(readiness_tx),
+            last_drop_warn: None,
         };
 
         let addr = actor.start();
@@ -73,7 +78,7 @@ impl NetEventBuffer {
         // Subscribe to InterfoldEvent on the bus
         bus.subscribe(EventType::SyncEnded, addr.clone().recipient());
 
-        (output_rx, NetEventBufferHandle { readiness })
+        (output, NetEventBufferHandle { readiness })
     }
 
     fn handle_interfold_event(&mut self, msg: InterfoldEvent) -> Result<()> {
@@ -93,9 +98,20 @@ impl NetEventBuffer {
     }
 
     fn forward_event(&mut self, event: NetEvent) -> Result<()> {
-        self.output_tx
-            .send(event)
-            .map_err(|e| anyhow!("Failed to forward event: {}", e))?;
+        // A broadcast send only fails when no receiver is alive. Consumers subscribe on
+        // `EffectsEnabled`, which the sync service publishes before `SyncEnded`; if that ordering
+        // ever slips the event is dropped, exactly as a late subscriber would have missed it.
+        // Warn at most once per ten seconds so a full buffer flush cannot flood the log.
+        if self.output_tx.send(event).is_err() {
+            let now = Instant::now();
+            let should_warn = self
+                .last_drop_warn
+                .is_none_or(|last| now.duration_since(last) > Duration::from_secs(10));
+            if should_warn {
+                warn!("Dropping buffered network event: no live subscribers on the output channel");
+                self.last_drop_warn = Some(now);
+            }
+        }
         Ok(())
     }
 

--- a/crates/net/src/event_buffer/handlers.rs
+++ b/crates/net/src/event_buffer/handlers.rs
@@ -127,6 +127,7 @@ mod tests {
             max_events: 8,
             max_bytes: 1_024,
             readiness: Some(readiness),
+            last_drop_warn: None,
         }
         .start();
 

--- a/crates/net/src/event_buffer/model_tests.rs
+++ b/crates/net/src/event_buffer/model_tests.rs
@@ -7,7 +7,7 @@
 use super::*;
 use crate::direct_requester::DirectRequesterTester;
 use crate::events::{NetCommand, NetEvent, PeerTarget};
-use std::sync::Arc;
+use crate::net_interface_handle::NetEventSubscriber;
 use tokio::sync::{broadcast, mpsc};
 
 #[test]
@@ -39,8 +39,8 @@ fn sync_fetch_budget_rejects_each_resource_limit_without_mutating_state() {
 #[tokio::test]
 async fn test_fetch_all_batched_events() {
     let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-    let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-    let net_events = Arc::new(net_events_rx);
+    let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+    let net_events = NetEventSubscriber::from(&net_events_tx);
 
     let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 
@@ -78,8 +78,8 @@ async fn test_fetch_all_batched_events() {
 #[tokio::test]
 async fn test_no_duplicate_events_across_batches() {
     let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-    let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-    let net_events = Arc::new(net_events_rx);
+    let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+    let net_events = NetEventSubscriber::from(&net_events_tx);
 
     let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 
@@ -129,8 +129,8 @@ async fn test_no_duplicate_events_across_batches() {
 #[tokio::test]
 async fn test_cursor_correctly_excludes_last_event_on_batch_boundary() {
     let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-    let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-    let net_events = Arc::new(net_events_rx);
+    let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+    let net_events = NetEventSubscriber::from(&net_events_tx);
 
     let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 
@@ -167,8 +167,8 @@ async fn test_cursor_correctly_excludes_last_event_on_batch_boundary() {
 #[tokio::test]
 async fn test_non_advancing_cursor_is_rejected() {
     let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-    let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-    let net_events = Arc::new(net_events_rx);
+    let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+    let net_events = NetEventSubscriber::from(&net_events_tx);
 
     let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
     let batch = EventBatch {
@@ -198,8 +198,8 @@ async fn test_non_advancing_cursor_is_rejected() {
 #[tokio::test]
 async fn test_single_batch_with_limit_exactly_matched_returns_done() {
     let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-    let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-    let net_events = Arc::new(net_events_rx);
+    let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+    let net_events = NetEventSubscriber::from(&net_events_tx);
 
     let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 
@@ -227,8 +227,8 @@ async fn test_single_batch_with_limit_exactly_matched_returns_done() {
 #[tokio::test]
 async fn test_three_batches_with_cursor_continuity() {
     let (net_cmds_tx, net_cmds_rx) = mpsc::channel::<NetCommand>(16);
-    let (net_events_tx, net_events_rx) = broadcast::channel::<NetEvent>(16);
-    let net_events = Arc::new(net_events_rx);
+    let (net_events_tx, _net_events_rx) = broadcast::channel::<NetEvent>(16);
+    let net_events = NetEventSubscriber::from(&net_events_tx);
 
     let requester = DirectRequester::builder(net_cmds_tx, net_events).build();
 

--- a/crates/net/src/event_buffer/tests.rs
+++ b/crates/net/src/event_buffer/tests.rs
@@ -4,6 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
+use crate::net_interface_handle::NetEventSubscriber;
 use std::{sync::Arc, time::Duration};
 
 use super::*;
@@ -79,13 +80,15 @@ async fn test_buffers_until_sync_ended() -> Result<()> {
     // Setup
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle()?.enable("test");
-    let (input_tx, input_rx) = broadcast::channel(16);
-    let (mut output_rx, handle) = NetEventBuffer::setup_with_limits(
+    let (input_tx, _input_rx) = broadcast::channel(16);
+    let input = NetEventSubscriber::from(&input_tx);
+    let (output, handle) = NetEventBuffer::setup_with_limits(
         &bus,
-        &input_rx,
+        &input,
         DEFAULT_MAX_BUFFERED_NET_EVENTS,
         DEFAULT_MAX_BUFFERED_NET_BYTES,
     );
+    let mut output_rx = output.subscribe();
 
     // Send events while syncing - should be buffered
     let event1 = NetEvent::GossipData(GossipData::GossipBytes(vec![1, 2, 3]));
@@ -139,9 +142,10 @@ async fn test_buffers_until_sync_ended() -> Result<()> {
 async fn startup_buffer_overflow_fails_readiness_without_dropping_oldest() -> Result<()> {
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle()?.enable("test-overflow");
-    let (input_tx, input_rx) = broadcast::channel(16);
+    let (input_tx, _input_rx) = broadcast::channel(16);
+    let input = NetEventSubscriber::from(&input_tx);
     let (_output_rx, handle) =
-        NetEventBuffer::setup_with_limits(&bus, &input_rx, 1, DEFAULT_MAX_BUFFERED_NET_BYTES);
+        NetEventBuffer::setup_with_limits(&bus, &input, 1, DEFAULT_MAX_BUFFERED_NET_BYTES);
 
     input_tx.send(NetEvent::GossipData(GossipData::GossipBytes(vec![1])))?;
     input_tx.send(NetEvent::GossipData(GossipData::GossipBytes(vec![2])))?;
@@ -163,11 +167,12 @@ async fn startup_buffer_overflow_fails_readiness_without_dropping_oldest() -> Re
 async fn startup_buffer_enforces_estimated_payload_bytes() -> Result<()> {
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle()?.enable("test-byte-overflow");
-    let (input_tx, input_rx) = broadcast::channel(16);
+    let (input_tx, _input_rx) = broadcast::channel(16);
+    let input = NetEventSubscriber::from(&input_tx);
     let event = NetEvent::GossipData(GossipData::GossipBytes(vec![0; 32]));
     let estimated_bytes = event.buffered_size_bytes();
     let (_output_rx, handle) =
-        NetEventBuffer::setup_with_limits(&bus, &input_rx, 16, estimated_bytes - 1);
+        NetEventBuffer::setup_with_limits(&bus, &input, 16, estimated_bytes - 1);
 
     input_tx.send(event)?;
 
@@ -191,9 +196,10 @@ async fn sync_control_burst_does_not_lag_or_consume_the_application_buffer() -> 
     let bus = system.handle()?.enable("net-control-flood");
     let event_tx = NetEventSender::new(EVENT_CHANNEL_SIZE, 1);
     let _raw_rx = event_tx.subscribe();
-    let input_rx = event_tx.application_subscribe();
-    let (mut output_rx, handle) =
-        NetEventBuffer::setup_with_limits(&bus, &input_rx, 1, DEFAULT_MAX_BUFFERED_NET_BYTES);
+    let input = event_tx.application_subscriber();
+    let (output, handle) =
+        NetEventBuffer::setup_with_limits(&bus, &input, 1, DEFAULT_MAX_BUFFERED_NET_BYTES);
+    let mut output_rx = output.subscribe();
 
     let control_events = sync_and_connection_control_events();
     assert!(control_events

--- a/crates/net/src/event_translation/actor.rs
+++ b/crates/net/src/event_translation/actor.rs
@@ -5,6 +5,7 @@
 
 use crate::domain::EventTranslationService;
 use crate::events::{GossipData, GossipPublishFailure, NetCommand, NetEvent};
+use crate::net_interface_handle::NetEventSubscriber;
 use crate::NetworkPolicy;
 use actix::prelude::*;
 use anyhow::Result;
@@ -13,9 +14,7 @@ use e3_events::{
     EventType, InterfoldEvent,
 };
 use e3_utils::MAILBOX_LIMIT;
-use std::sync::Arc;
 use std::{collections::HashMap, time::Duration};
-use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 
@@ -72,11 +71,11 @@ impl NetEventTranslator {
     pub fn setup(
         bus: &BusHandle,
         tx: &mpsc::Sender<NetCommand>,
-        rx: &Arc<broadcast::Receiver<NetEvent>>,
+        rx: &NetEventSubscriber,
         topic: &str,
         network: NetworkPolicy,
     ) -> Addr<Self> {
-        let mut rx = rx.resubscribe();
+        let mut rx = rx.subscribe();
         let addr = NetEventTranslator::new(bus, tx, topic, network).start();
 
         // Listen on all events

--- a/crates/net/src/events.rs
+++ b/crates/net/src/events.rs
@@ -4,6 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
+use crate::net_interface_handle::NetEventSubscriber;
 use crate::{
     direct_responder::DirectResponder,
     domain::wire::{decode, MAX_GOSSIP_BYTES},
@@ -449,7 +450,7 @@ impl DocumentPublishedNotification {
 /// Generic helper for the command-response pattern with correlation IDs
 pub async fn call_and_await_response<F, R>(
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     command: NetCommand,
     matcher: F,
     timeout: Duration,
@@ -457,8 +458,8 @@ pub async fn call_and_await_response<F, R>(
 where
     F: Fn(&NetEvent) -> Option<Result<R>>,
 {
-    // Resubscribe first to avoid missing events
-    let mut rx = net_events.resubscribe();
+    // Subscribe before sending the command so the response cannot be missed
+    let mut rx = net_events.subscribe();
 
     // Extract correlation_id from command
     let Some(id) = command.correlation_id() else {
@@ -508,14 +509,14 @@ where
 }
 
 pub async fn await_event<F, R>(
-    net_events: &Arc<broadcast::Receiver<NetEvent>>,
+    net_events: &NetEventSubscriber,
     matcher: F,
     timeout: Duration,
 ) -> Result<R>
 where
     F: Fn(&NetEvent) -> Option<R>,
 {
-    let mut rx = net_events.resubscribe();
+    let mut rx = net_events.subscribe();
 
     let result = tokio::time::timeout(timeout, async {
         loop {

--- a/crates/net/src/lib.rs
+++ b/crates/net/src/lib.rs
@@ -120,7 +120,7 @@ pub fn setup_net_with_limits(
     let _net_sync = NetSyncManager::setup(
         &bus,
         &interface.tx(),
-        &Arc::new(interface.rx()),
+        &interface.events(),
         eventstore.into(),
         topic,
         network.clone(),
@@ -130,11 +130,10 @@ pub fn setup_net_with_limits(
     // channel that the sync manager consumes.
     let (rx, buffer_handle) = NetEventBuffer::setup_with_limits(
         &bus,
-        &interface.application_rx(),
+        &interface.application_events(),
         max_buffered_events,
         max_buffered_bytes,
     );
-    let rx = Arc::new(rx);
     let tx = interface.tx();
     let network = network.clone();
 

--- a/crates/net/src/net_interface.rs
+++ b/crates/net/src/net_interface.rs
@@ -282,12 +282,7 @@ impl Libp2pNetInterface {
     }
 
     pub fn handle(&self) -> NetInterfaceHandle {
-        NetInterfaceHandle::new(
-            self.cmd_tx.clone(),
-            self.event_tx.subscribe(),
-            self.event_tx.application_subscribe(),
-            self.status.clone(),
-        )
+        NetInterfaceHandle::new(self.cmd_tx.clone(), &self.event_tx, self.status.clone())
     }
 
     pub async fn start(&mut self) -> Result<()> {

--- a/crates/net/src/net_interface_handle.rs
+++ b/crates/net/src/net_interface_handle.rs
@@ -32,52 +32,89 @@ impl NetEventSender {
         Self { raw, application }
     }
 
-    /// Sends one event to its required channels.
+    /// Sends one event to its required channels and returns the number of receivers reached.
+    ///
+    /// A broadcast send only fails when no receiver is alive. Consumers subscribe lazily, so that
+    /// is not an error for the producer: the event has nobody to go to and is dropped, exactly as
+    /// it would be for a receiver that subscribes a moment later.
     pub fn send(&self, event: NetEvent) -> Result<usize, broadcast::error::SendError<NetEvent>> {
         if !event.requires_application_delivery() {
-            return self.raw.send(event);
+            return Ok(self.raw.send(event).unwrap_or(0));
         }
 
-        let raw_result = self.raw.send(event.clone());
-        let application_result = self.application.send(event);
-
-        match (raw_result, application_result) {
-            (Ok(receivers), _) | (Err(_), Ok(receivers)) => Ok(receivers),
-            (Err(error), Err(_)) => Err(error),
-        }
+        let raw = self.raw.send(event.clone()).unwrap_or(0);
+        let application = self.application.send(event).unwrap_or(0);
+        Ok(raw + application)
     }
 
     pub(crate) fn subscribe(&self) -> broadcast::Receiver<NetEvent> {
         self.raw.subscribe()
     }
 
-    pub(crate) fn application_subscribe(&self) -> broadcast::Receiver<NetEvent> {
-        self.application.subscribe()
-    }
-
     pub(crate) fn len(&self) -> usize {
         self.raw.len()
+    }
+
+    pub(crate) fn subscriber(&self) -> NetEventSubscriber {
+        NetEventSubscriber::from(&self.raw)
+    }
+
+    pub(crate) fn application_subscriber(&self) -> NetEventSubscriber {
+        NetEventSubscriber::from(&self.application)
+    }
+}
+
+/// Cheap, cloneable factory for live `NetEvent` receivers.
+///
+/// Holds a `WeakSender` rather than a template `Receiver` or a strong `Sender`, so a stored
+/// subscriber neither pins the channel queue (a never-polled receiver would keep every event
+/// queued and make `NetEventSender::len()` report permanent backpressure) nor keeps the channel
+/// open after the producer drops it: receivers still observe `RecvError::Closed` on shutdown.
+#[derive(Debug, Clone)]
+pub struct NetEventSubscriber {
+    tx: broadcast::WeakSender<NetEvent>,
+}
+
+impl NetEventSubscriber {
+    /// Returns a receiver that sees every event sent after this call. If the producer has
+    /// already gone away the receiver reports `RecvError::Closed` immediately.
+    pub fn subscribe(&self) -> broadcast::Receiver<NetEvent> {
+        match self.tx.upgrade() {
+            Some(tx) => tx.subscribe(),
+            None => {
+                let (tx, rx) = broadcast::channel(1);
+                drop(tx);
+                rx
+            }
+        }
+    }
+}
+
+impl From<&broadcast::Sender<NetEvent>> for NetEventSubscriber {
+    fn from(tx: &broadcast::Sender<NetEvent>) -> Self {
+        Self { tx: tx.downgrade() }
     }
 }
 
 #[derive(Debug)]
 pub struct NetInterfaceHandle {
     tx: mpsc::Sender<NetCommand>,
-    rx: broadcast::Receiver<NetEvent>,
-    application_rx: broadcast::Receiver<NetEvent>,
+    /// Weak subscribers: the handle neither pins the broadcast queue nor keeps the channels open
+    /// once the interface that owns the `NetEventSender` shuts down.
+    events: NetEventSubscriber,
+    application_events: NetEventSubscriber,
     status: NetworkStatus,
 }
 impl NetInterfaceHandle {
     pub(crate) fn new(
         tx: mpsc::Sender<NetCommand>,
-        rx: broadcast::Receiver<NetEvent>,
-        application_rx: broadcast::Receiver<NetEvent>,
+        event_tx: &NetEventSender,
         status: NetworkStatus,
     ) -> Self {
         Self {
             tx,
-            rx,
-            application_rx,
+            events: event_tx.subscriber(),
+            application_events: event_tx.application_subscriber(),
             status,
         }
     }
@@ -89,12 +126,18 @@ impl NetInterfaceHandle {
 
 pub trait NetInterface: Sized {
     fn tx(&self) -> mpsc::Sender<NetCommand>;
-    fn rx(&self) -> broadcast::Receiver<NetEvent>;
-    /// Returns a receiver that contains only application-delivery events.
-    fn application_rx(&self) -> broadcast::Receiver<NetEvent>;
+    /// Returns a subscriber for the raw event channel.
+    fn events(&self) -> NetEventSubscriber;
+    /// Returns a subscriber for the application-delivery event channel.
+    fn application_events(&self) -> NetEventSubscriber;
     fn status(&self) -> NetworkStatus;
-    fn handle(&self) -> NetInterfaceHandle {
-        NetInterfaceHandle::from(self)
+    /// Returns a live receiver on the raw event channel.
+    fn rx(&self) -> broadcast::Receiver<NetEvent> {
+        self.events().subscribe()
+    }
+    /// Returns a live receiver that contains only application-delivery events.
+    fn application_rx(&self) -> broadcast::Receiver<NetEvent> {
+        self.application_events().subscribe()
     }
 }
 
@@ -107,27 +150,17 @@ pub struct NetChannelBridge {
     event_tx: NetEventSender,
 }
 
-impl NetInterfaceHandle {
-    pub fn from(interface: &impl NetInterface) -> Self {
-        Self {
-            tx: interface.tx(),
-            rx: interface.rx(),
-            application_rx: interface.application_rx(),
-            status: interface.status(),
-        }
-    }
-}
 impl NetInterface for NetInterfaceHandle {
-    fn rx(&self) -> broadcast::Receiver<NetEvent> {
-        self.rx.resubscribe()
-    }
-
     fn tx(&self) -> mpsc::Sender<NetCommand> {
         self.tx.clone()
     }
 
-    fn application_rx(&self) -> broadcast::Receiver<NetEvent> {
-        self.application_rx.resubscribe()
+    fn events(&self) -> NetEventSubscriber {
+        self.events.clone()
+    }
+
+    fn application_events(&self) -> NetEventSubscriber {
+        self.application_events.clone()
     }
 
     fn status(&self) -> NetworkStatus {
@@ -169,12 +202,7 @@ pub fn create_channel_bridge_with_application_event_capacity(
         }
     });
 
-    let handle = NetInterfaceHandle {
-        tx: m_cmd_tx.clone(),
-        rx: event_tx.subscribe(),
-        application_rx: event_tx.application_subscribe(),
-        status: NetworkStatus::new(0),
-    };
+    let handle = NetInterfaceHandle::new(m_cmd_tx.clone(), &event_tx, NetworkStatus::new(0));
 
     let inverted = NetChannelBridge {
         tx: m_cmd_tx,
@@ -227,6 +255,58 @@ mod tests {
     use super::*;
 
     #[test]
+    fn subscriber_closes_when_the_producer_drops() {
+        let event_tx = NetEventSender::new(4, 4);
+        let (cmd_tx, _cmd_rx) = mpsc::channel(1);
+        let handle = NetInterfaceHandle::new(cmd_tx, &event_tx, NetworkStatus::new(0));
+        let mut live_rx = handle.application_rx();
+
+        drop(event_tx);
+
+        assert!(matches!(
+            live_rx.try_recv(),
+            Err(broadcast::error::TryRecvError::Closed)
+        ));
+        assert!(matches!(
+            handle.rx().try_recv(),
+            Err(broadcast::error::TryRecvError::Closed)
+        ));
+    }
+
+    #[test]
+    fn send_without_subscribers_is_not_an_error() {
+        let event_tx = NetEventSender::new(1, 1);
+        assert_eq!(
+            event_tx
+                .send(NetEvent::GossipData(GossipData::GossipBytes(vec![1])))
+                .expect("no subscriber is not a producer error"),
+            0
+        );
+    }
+
+    #[test]
+    fn handle_does_not_pin_the_event_queue() {
+        let event_tx = NetEventSender::new(4, 4);
+        let (cmd_tx, _cmd_rx) = mpsc::channel(1);
+        let handle = NetInterfaceHandle::new(cmd_tx, &event_tx, NetworkStatus::new(0));
+        let mut rx = handle.rx();
+
+        for i in 0..3u8 {
+            event_tx
+                .send(NetEvent::GossipData(GossipData::GossipBytes(vec![i])))
+                .expect("live subscriber must receive");
+        }
+        assert_eq!(event_tx.len(), 3);
+
+        while rx.try_recv().is_ok() {}
+        assert_eq!(
+            event_tx.len(),
+            0,
+            "queue must drain once the only live receiver has consumed it"
+        );
+    }
+
+    #[test]
     fn application_event_send_succeeds_with_either_channel_subscribed() {
         let raw_only = NetEventSender::new(1, 1);
         let mut raw_rx = raw_only.subscribe();
@@ -236,7 +316,7 @@ mod tests {
         assert!(matches!(raw_rx.try_recv(), Ok(NetEvent::GossipData(_))));
 
         let application_only = NetEventSender::new(1, 1);
-        let mut application_rx = application_only.application_subscribe();
+        let mut application_rx = application_only.application_subscriber().subscribe();
         application_only
             .send(NetEvent::GossipData(GossipData::GossipBytes(vec![2])))
             .expect("application delivery must succeed without a raw subscriber");

--- a/crates/net/src/network_sync/actor.rs
+++ b/crates/net/src/network_sync/actor.rs
@@ -4,6 +4,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
+use crate::net_interface_handle::NetEventSubscriber;
 use actix::{Actor, Addr, AsyncContext, Handler, Message, Recipient, ResponseFuture};
 use anyhow::{bail, Context, Result};
 use e3_events::{
@@ -18,10 +19,9 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     convert::TryInto,
-    sync::Arc,
     time::Duration,
 };
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -107,7 +107,7 @@ pub struct NetSyncManager {
     /// NetCommand sender to forward commands to the Libp2pNetInterface
     tx: mpsc::Sender<NetCommand>,
     /// NetEvents receiver to receive events
-    rx: Arc<broadcast::Receiver<NetEvent>>,
+    rx: NetEventSubscriber,
     eventstore: Recipient<EventStoreQueryBy<TsAgg>>,
     requests: HashMap<CorrelationId, PendingSyncRequest>,
     /// Pure readiness state machine.
@@ -132,7 +132,7 @@ impl NetSyncManager {
     pub fn new(
         bus: &BusHandle,
         tx: &mpsc::Sender<NetCommand>,
-        rx: &Arc<broadcast::Receiver<NetEvent>>,
+        rx: &NetEventSubscriber,
         eventstore: Recipient<EventStoreQueryBy<TsAgg>>,
         topic: &str,
         network: NetworkPolicy,
@@ -140,7 +140,7 @@ impl NetSyncManager {
         Self {
             bus: bus.clone(),
             tx: tx.clone(),
-            rx: Arc::clone(rx),
+            rx: rx.clone(),
             eventstore,
             requests: HashMap::new(),
             readiness: NetReadiness::new(),

--- a/crates/net/src/network_sync/effects/fetch_history.rs
+++ b/crates/net/src/network_sync/effects/fetch_history.rs
@@ -3,10 +3,11 @@
 //! Bounded historical-event fetching, validation, and recovery retries.
 
 use super::*;
+use crate::net_interface_handle::NetEventSubscriber;
 
 pub(in crate::actors::net_sync_manager) async fn fetch_historical_events_for_aggregate(
     net_cmds: &mpsc::Sender<NetCommand>,
-    net_events: &Arc<broadcast::Receiver<NetEvent>>,
+    net_events: &NetEventSubscriber,
     aggregate_id: AggregateId,
     since: u128,
     budget: &mut SyncFetchBudget,
@@ -71,7 +72,7 @@ pub(in crate::actors::net_sync_manager) fn eligible_sync_cursor(
 
 pub(in crate::actors::net_sync_manager) async fn handle_sync_request_event(
     net_cmds: mpsc::Sender<NetCommand>,
-    net_events: Arc<broadcast::Receiver<NetEvent>>,
+    net_events: NetEventSubscriber,
     event: TypedEvent<HistoricalNetSyncStart>,
     address: impl Into<Recipient<TypedEvent<SyncRequestSucceeded>>>,
     wait_for_event: bool,

--- a/crates/net/src/network_sync/effects/readiness.rs
+++ b/crates/net/src/network_sync/effects/readiness.rs
@@ -3,6 +3,7 @@
 //! Own network readiness, fallback timing, and ingress task setup.
 
 use super::*;
+use crate::net_interface_handle::NetEventSubscriber;
 
 impl NetSyncManager {
     /// Apply a readiness decision: publish `NetReady`, or schedule the fallback timeout.
@@ -41,12 +42,12 @@ impl NetSyncManager {
     pub fn setup(
         bus: &BusHandle,
         tx: &mpsc::Sender<NetCommand>,
-        rx: &Arc<broadcast::Receiver<NetEvent>>,
+        rx: &NetEventSubscriber,
         eventstore: Recipient<EventStoreQueryBy<TsAgg>>,
         topic: &str,
         network: NetworkPolicy,
     ) -> Addr<Self> {
-        let mut events = rx.resubscribe();
+        let mut events = rx.subscribe();
         let addr = Self::new(bus, tx, rx, eventstore, topic, network).start();
 
         bus.subscribe(EventType::HistoricalNetSyncStart, addr.clone().recipient());

--- a/crates/net/src/network_sync/tests.rs
+++ b/crates/net/src/network_sync/tests.rs
@@ -5,6 +5,7 @@
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
 use super::*;
+use crate::net_interface_handle::NetEventSubscriber;
 use crate::{
     direct_responder::ChannelType,
     events::{IncomingRequest, NetCommand},
@@ -49,8 +50,8 @@ fn manager_with_recording_store(
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle().unwrap().enable("test");
     let (tx, rx) = mpsc::channel::<NetCommand>(100);
-    let (_evt_tx, evt_rx) = broadcast::channel::<NetEvent>(100);
-    let evt_rx = Arc::new(evt_rx);
+    let (evt_tx, _evt_rx) = broadcast::channel::<NetEvent>(100);
+    let evt_rx = NetEventSubscriber::from(&evt_tx);
     let eventstore = RecordingEventStore { queries: query_tx }
         .start()
         .recipient();
@@ -168,8 +169,8 @@ fn historical_sync_cursor_keeps_only_active_network_chains() {
 #[actix::test]
 async fn local_only_cursor_completes_without_a_peer_request() {
     let (net_tx, mut net_rx) = mpsc::channel::<NetCommand>(1);
-    let (_event_tx, event_rx) = broadcast::channel::<NetEvent>(1);
-    let event_rx = Arc::new(event_rx);
+    let (event_tx, _event_rx) = broadcast::channel::<NetEvent>(1);
+    let event_rx = NetEventSubscriber::from(&event_tx);
     let (response_tx, response_rx) =
         e3_utils::actix::channel::oneshot::<TypedEvent<SyncRequestSucceeded>>();
     let start = HistoricalNetSyncStart::new(BTreeMap::from([(AggregateId::new(0), 10)]));
@@ -201,8 +202,8 @@ async fn rebroadcast_only_gossips_forwardable_own_artifacts() {
     let system = EventSystem::new().with_fresh_bus();
     let bus = system.handle().unwrap().enable("test");
     let (tx, mut rx) = mpsc::channel::<NetCommand>(100);
-    let (_evt_tx, evt_rx) = broadcast::channel::<NetEvent>(100);
-    let evt_rx = Arc::new(evt_rx);
+    let (evt_tx, _evt_rx) = broadcast::channel::<NetEvent>(100);
+    let evt_rx = NetEventSubscriber::from(&evt_tx);
     let eventstore = NoopEventStore.start().recipient();
 
     let mut mgr = NetSyncManager::new(

--- a/crates/tests/tests/integration.rs
+++ b/crates/tests/tests/integration.rs
@@ -2371,7 +2371,7 @@ async fn test_p2p_actor_forwards_events_to_network() -> Result<()> {
         .with_aggregate_config(aggregate_config);
     let bus = system.handle()?.enable("test");
     let history_collector = bus.history();
-    let event_rx = Arc::new(event_tx.subscribe());
+    let event_rx = e3_net::NetEventSubscriber::from(&event_tx);
     // Pas cmd and event channels to NetEventTranslator
     NetEventTranslator::setup(
         &bus,
@@ -2468,7 +2468,7 @@ async fn test_p2p_actor_forwards_events_to_bus() -> Result<()> {
 
     // Setup elements in test
     let (cmd_tx, _) = mpsc::channel(100); // Transmit byte events to the network
-    let (event_tx, event_rx) = broadcast::channel(100); // Receive byte events from the network
+    let (event_tx, _event_rx) = broadcast::channel(100); // Receive byte events from the network
     let aggregate_config =
         AggregateConfig::new(HashMap::from([(AggregateId::new(1), Duration::ZERO)]));
     let system = EventSystem::new()
@@ -2480,7 +2480,7 @@ async fn test_p2p_actor_forwards_events_to_bus() -> Result<()> {
     NetEventTranslator::setup(
         &bus,
         &cmd_tx,
-        &Arc::new(event_rx),
+        &e3_net::NetEventSubscriber::from(&event_tx),
         "mytopic",
         e3_net::NetworkPolicy::local_unrestricted(),
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved network event subscription handling across requests, publishing, synchronization, translation, and buffering.
  * Events are no longer held open unnecessarily when there are no active listeners.
  * Unsubscribed event sends now complete successfully without disrupting network processing.
  * Buffered events dropped during output failures now generate rate-limited warnings instead of stopping the buffer.

* **Tests**
  * Updated coverage for event delivery, buffering limits, shutdown behavior, synchronization, and integration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->