### PR TITLE
fix: increase finalize tx timeout

### DIFF
--- a/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
+++ b/agent/flow-trace/03_E3_REQUEST_AND_COMMITTEE.md
@@ -368,10 +368,15 @@ CommitteeFinalizer actor receives CommitteeRequested event
 │   ├─ local TicketGenerated.party_index is known
 │   └─ EffectsEnabled has fired
 │
-├─ Calculates wait time:
+├─ Calculates wait time (finalization_delay_seconds):
 │   wait = max(committeeDeadline - currentTimestamp, 0)
 │          + 1 second
-│          + party_index * 5 seconds
+│          + party_index * 30 seconds
+│   → The 30-second step must exceed one block interval plus the log read.
+│     A member cancels its own attempt only after it observes
+│     CommitteeFinalized, so a shorter step makes every member send a
+│     transaction that reverts. The step is paid only while earlier
+│     members stay silent.
 │
 ├─ Schedules a staggered timer
 │
@@ -388,19 +393,20 @@ CommitteeFinalizer actor receives CommitteeRequested event
 ```
 CiphernodeRegistrySolWriter receives CommitteeFinalizeRequested
 │
-├─ Preflight: should_finalize_committee() (eth_call)
-│   └─ Skips the transaction when the committee is not finalizable
-│      (CommitteeAlreadyFinalized / CommitteeNotRequested /
-│       SubmissionWindowNotClosed / ThresholdNotMet)
+├─ Preflight: committee_finalization_terminal() (eth_call)
+│   └─ Skips the transaction when finalizeCommittee reverts with
+│      CommitteeAlreadyFinalized, which covers both the Finalized and the
+│      Failed stage. Another member can finalize between the stagger tick
+│      and this call, and a transaction sent after that point is mined with
+│      a failed receipt and burns gas.
 │
 └─ Calls contract.finalizeCommittee(e3Id).send()
     │
     │  If the transaction is mined with a failed receipt, the writer runs the
-    │  state check again (send_tx_idempotent in crates/evm/src/helpers.rs).
-    │  A revert with CommitteeAlreadyFinalized plus a non-empty
-    │  getActiveCommitteeNodes list shows that another sender finalized after
-    │  the preflight, so the node logs the outcome and reports no error. The
-    │  Failed stage gives the same revert with an empty list and stays an error.
+    │  same state check again (send_tx_idempotent in crates/evm/src/helpers.rs).
+    │  A terminal state means no chain work remains, so the node logs the
+    │  outcome and reports no error. Any other failure stays an error and
+    │  retries after 30 seconds.
     │
     │  ┌─── ON-CHAIN (CiphernodeRegistryOwnable) ──────────────┐
     │  │                                                         │
@@ -551,11 +557,11 @@ A ready committee must finalize at or before its absolute DKG deadline.
 5. **Permissionless finalization**: Anyone can call `finalizeCommittee()` after the submission
    deadline and through the absolute DKG deadline. Delayed finalization reduces the remaining DKG
    time instead of extending the paid lifecycle. After the DKG deadline, anyone can fail an
-   unfinalized ready committee. Because staggered timers can overlap, more than one node can send
-   the transaction. The losing transaction reverts with `CommitteeAlreadyFinalized`; the writer
-   re-reads the committee after the failure and treats the revert as complete only when the registry
-   reports a finalized committee. A committee that another sender finalized into the `Failed` stage
-   produces the same revert and stays an error.
+   unfinalized ready committee. The staggered timers keep one member ahead of the next, and the
+   writer reads the chain again before it sends. Both guards can still lose to a transaction that
+   lands in the same block, so more than one node can send. The losing transaction reverts with
+   `CommitteeAlreadyFinalized`; the writer re-reads the state after the failure and reports no error
+   when finalization is terminal.
 
 6. **IMT root snapshot**: The Merkle tree root is captured at request time. Nodes that join/leave
    after the request don't affect this E3's committee. A removed node's current-tree slot can be

--- a/agent/flow-trace/04_DKG_AND_COMPUTATION.md
+++ b/agent/flow-trace/04_DKG_AND_COMPUTATION.md
@@ -694,6 +694,10 @@ phase.
   └─ Calls contract.publishCommitteePublicKey(e3_id, publicKey) after the
      commitment is available, including after restart
      → A terminal result clears the intent; a retryable failure keeps it and retries after 30s
+     → A restart replays the intent, so an unfinished publication still reaches the chain.
+       E3RequestComplete that arrives before EffectsEnabled comes from that same replay and
+       drops the intent: a completed request published its candidate in an earlier run, and
+       repeating it only spends gas
         │
         │  ┌─── ON-CHAIN (CiphernodeRegistryOwnable) ──────────┐
         │  │                                                     │

--- a/crates/aggregator/src/committee_finalization/actor.rs
+++ b/crates/aggregator/src/committee_finalization/actor.rs
@@ -24,7 +24,15 @@ use tracing::{error, info};
 mod handlers;
 
 const FINALIZATION_BUFFER_SECONDS: u64 = 1;
-const FINALIZE_INTERVAL_SECONDS: u64 = 5;
+/// Delay between one committee member's finalization attempt and the next.
+///
+/// A member cancels its own attempt when it observes `CommitteeFinalized`. That
+/// observation needs the leader's transaction to be mined and its log to be
+/// read. The interval must therefore exceed several block times, or every
+/// member sends a transaction that reverts with `CommitteeAlreadyFinalized`.
+/// The delay applies only while earlier members stay silent, so a larger value
+/// costs nothing when the first member finalizes.
+const FINALIZE_INTERVAL_SECONDS: u64 = 30;
 const FINALIZATION_RPC_RETRY_SECONDS: u64 = 30;
 pub const COMMITTEE_FINALIZER_RECOVERY_SCHEMA_VERSION: u32 = 1;
 
@@ -56,6 +64,19 @@ impl CommitteeFinalizerRecoveryState {
         self.pending_requests.remove(e3_id);
         self.tickets.remove(e3_id);
     }
+}
+
+/// Seconds a committee member waits after the submission window closes before it
+/// attempts finalization.
+///
+/// Members attempt in `party_index` order. Each step must be long enough for the
+/// previous member's transaction to be mined and for its `CommitteeFinalized`
+/// log to be read, or every member sends a transaction that reverts.
+fn finalization_delay_seconds(committee_deadline: u64, now: u64, party_index: u64) -> u64 {
+    committee_deadline
+        .saturating_sub(now)
+        .saturating_add(FINALIZATION_BUFFER_SECONDS)
+        .saturating_add(party_index.saturating_mul(FINALIZE_INTERVAL_SECONDS))
 }
 
 /// CommitteeFinalizer is an actor that listens to CommitteeRequested events and dispatches
@@ -160,12 +181,11 @@ impl CommitteeFinalizer {
             fut.into_actor(self)
                 .then(move |current_timestamp, act, ctx| {
                     if let Some(current_timestamp) = current_timestamp {
-                        let seconds_until_deadline = committee_deadline
-                            .saturating_sub(current_timestamp)
-                            .saturating_add(FINALIZATION_BUFFER_SECONDS)
-                            .saturating_add(
-                                party_index.saturating_mul(FINALIZE_INTERVAL_SECONDS),
-                            );
+                        let seconds_until_deadline = finalization_delay_seconds(
+                            committee_deadline,
+                            current_timestamp,
+                            party_index,
+                        );
 
                         info!(
                             e3_id = %e3_id,
@@ -246,5 +266,39 @@ impl Actor for CommitteeFinalizer {
     type Context = Context<Self>;
     fn started(&mut self, ctx: &mut Self::Context) {
         ctx.set_mailbox_capacity(MAILBOX_LIMIT);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{finalization_delay_seconds, FINALIZE_INTERVAL_SECONDS};
+
+    /// Longest block interval observed on Sepolia. The stagger must exceed it,
+    /// plus the log read that cancels a pending attempt.
+    const OBSERVED_BLOCK_INTERVAL_SECONDS: u64 = 18;
+
+    #[test]
+    fn the_first_member_attempts_right_after_the_deadline() {
+        assert_eq!(finalization_delay_seconds(1_000, 900, 0), 101);
+    }
+
+    #[test]
+    fn each_member_waits_for_the_previous_attempt_to_reach_the_chain() {
+        let first = finalization_delay_seconds(1_000, 1_000, 0);
+        let second = finalization_delay_seconds(1_000, 1_000, 1);
+
+        assert!(
+            second - first > OBSERVED_BLOCK_INTERVAL_SECONDS,
+            "stagger {} must exceed one block interval",
+            second - first
+        );
+    }
+
+    #[test]
+    fn a_passed_deadline_keeps_the_stagger() {
+        assert_eq!(
+            finalization_delay_seconds(1_000, 5_000, 3),
+            1 + 3 * FINALIZE_INTERVAL_SECONDS
+        );
     }
 }

--- a/crates/evm/src/ciphernode_registry/effects.rs
+++ b/crates/evm/src/ciphernode_registry/effects.rs
@@ -120,7 +120,15 @@ pub async fn finalize_committee_on_registry<P: Provider + WalletProvider + Clone
     contract_address: Address,
     e3_id: E3id,
 ) -> Result<TxOutcome> {
-    let e3_id_u256: U256 = e3_id.try_into()?;
+    let e3_id_u256: U256 = e3_id.clone().try_into()?;
+
+    // Members finalize on a stagger. Another member can finalize between the
+    // stagger tick and this call, so read the chain first. Without this check
+    // the transaction is mined with a failed receipt and burns gas.
+    if committee_finalization_terminal(provider.clone(), contract_address, e3_id_u256).await? {
+        info!(e3_id = %e3_id, "Committee already finalized on chain; skipping finalizeCommittee");
+        return Ok(TxOutcome::AlreadySettled);
+    }
 
     let settled_provider = provider.clone();
     let settled = || async move {

--- a/crates/evm/src/ciphernode_registry/handlers.rs
+++ b/crates/evm/src/ciphernode_registry/handlers.rs
@@ -37,6 +37,26 @@ fn mark_request_complete(
     }
 }
 
+/// Settle the publication gate for a completed request and report whether an
+/// intent survives.
+///
+/// A completed request that arrives before effects are enabled comes from event
+/// replay. Its key candidate reached the chain in an earlier run, so the
+/// replayed intent must go; otherwise the writer publishes the same candidate
+/// again after every restart. A completed request that arrives while effects
+/// run can still overtake an in-flight publication, so that intent stays.
+fn settle_publication_for_completed_request(
+    publication: &mut ReplaySubmissionGate<E3id, PublicKeyAggregated>,
+    e3_id: &E3id,
+    effects_enabled: bool,
+) -> bool {
+    if !effects_enabled {
+        publication.finish(e3_id, true);
+    }
+
+    publication.contains(e3_id)
+}
+
 fn finish_completed_publication(
     active_aggregators: &mut HashMap<E3id, bool>,
     completed_requests: &mut HashSet<E3id>,
@@ -196,7 +216,11 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<E3RequestComplete>
     type Result = ();
 
     fn handle(&mut self, msg: E3RequestComplete, _: &mut Self::Context) -> Self::Result {
-        let publication_pending = self.publication.contains(&msg.e3_id);
+        let publication_pending = settle_publication_for_completed_request(
+            &mut self.publication,
+            &msg.e3_id,
+            self.effects_enabled,
+        );
         self.ticket_submissions.finish(&msg.e3_id, true);
         self.committee_finalizations.finish(&msg.e3_id, true);
         mark_request_complete(
@@ -360,12 +384,16 @@ impl<P: Provider + WalletProvider + Clone + 'static> Handler<SubmitCommitteeFina
 
 #[cfg(test)]
 mod tests {
-    use super::{finish_completed_publication, mark_request_complete, update_request_registry};
+    use super::{
+        finish_completed_publication, mark_request_complete,
+        settle_publication_for_completed_request, update_request_registry, ReplaySubmissionGate,
+    };
     use alloy::primitives::Address;
     use e3_events::{
-        DkgFoldAttestationContext, DkgFoldAttestationContextEstablished, E3id,
-        DKG_FOLD_ATTESTATION_CONTEXT_SCHEMA_VERSION,
+        DkgFoldAttestationContext, DkgFoldAttestationContextEstablished, E3id, OrderedSet,
+        PublicKeyAggregated, DKG_FOLD_ATTESTATION_CONTEXT_SCHEMA_VERSION,
     };
+    use e3_utils::ArcBytes;
     use std::collections::{HashMap, HashSet};
 
     #[test]
@@ -402,6 +430,48 @@ mod tests {
 
         assert!(!update_request_registry(&mut registries, &event));
         assert!(!registries.contains_key(&e3_id));
+    }
+
+    fn publication_intent(e3_id: &E3id) -> PublicKeyAggregated {
+        PublicKeyAggregated {
+            pubkey: ArcBytes::from_bytes(&[1, 2, 3]),
+            e3_id: e3_id.clone(),
+            nodes: OrderedSet::from(vec![]),
+            committee_addresses: vec![],
+            honest_committee_addresses: vec![],
+            pk_commitment: [7u8; 32],
+            dkg_aggregator_proof: None,
+            dkg_attestation_bundle: None,
+        }
+    }
+
+    #[test]
+    fn replayed_completion_drops_the_publication_intent() {
+        let e3_id = E3id::new("10", 1);
+        let mut publication = ReplaySubmissionGate::new();
+        publication.record(e3_id.clone(), publication_intent(&e3_id));
+
+        // Effects are disabled while the commit log replays.
+        let pending = settle_publication_for_completed_request(&mut publication, &e3_id, false);
+
+        assert!(!pending);
+        assert!(!publication.contains(&e3_id));
+
+        publication.enable_effects();
+        assert!(publication.start(&e3_id).is_none());
+    }
+
+    #[test]
+    fn live_completion_retains_the_publication_intent() {
+        let e3_id = E3id::new("11", 1);
+        let mut publication = ReplaySubmissionGate::new();
+        publication.record(e3_id.clone(), publication_intent(&e3_id));
+        publication.enable_effects();
+
+        let pending = settle_publication_for_completed_request(&mut publication, &e3_id, true);
+
+        assert!(pending);
+        assert!(publication.start(&e3_id).is_some());
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Committee finalization now staggers members at 30-second intervals, reducing submission conflicts.
  * Finalization handles already-completed committees gracefully and retries other submission errors.
  * Registry publication work resumes safely after restarts without duplicating completed publications.
  * Replayed completion events are handled correctly while active publication requests remain pending.
* **Documentation**
  * Updated permissionless-finalization guidance to explain state checks and terminal failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->