### PR TITLE
fix: tag from main

### DIFF
--- a/.github/workflows/crisp-docker.yml
+++ b/.github/workflows/crisp-docker.yml
@@ -58,7 +58,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
-            ${{ github.ref == 'refs/heads/release' && format('{0}:latest', env.IMAGE_NAME) || '' }}
+            ${{ github.ref == 'refs/heads/main' && format('{0}:latest', env.IMAGE_NAME) || '' }}
           build-args: |
             SKIP_SOLIDITY=1
           cache-from: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image publishing so the `latest` tag is applied for builds from the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->