### PR TITLE
fix(release): support stable npm publication

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -21,6 +21,7 @@ env:
   SUPPORT_DOCKERFILE_PATH: crates/support/Dockerfile
   CIPHERNODE_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/ciphernode
   SUPPORT_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/e3-support
+  NPM_VERSION: '11.19.1'
   NOIR_TOOLCHAIN: v1.0.0-beta.26
   MNEMONIC: 'test test test test test test test test test test test junk'
   INFURA_API_KEY: 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
@@ -224,8 +225,8 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Upgrade npm
-        run: npm install -g npm@latest
+      - name: Install npm
+        run: npm install -g "npm@${NPM_VERSION}"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,7 +1,6 @@
 name: Release
 
 permissions:
-  actions: write
   id-token: write
   contents: write
   packages: write
@@ -45,14 +44,6 @@ jobs:
       - name: Validate release candidate
         id: release
         run: node scripts/release.mjs prepare
-
-  candidate-ci:
-    name: Validate Exact Release Candidate
-    needs: validate-and-prepare
-    uses: ./.github/workflows/ci.yml
-    with:
-      release_candidate: true
-    secrets: inherit
 
   build-ciphernode-image-release:
     name: Build & Push ciphernode (release)
@@ -318,12 +309,12 @@ jobs:
             dist/circuits/checksums.json
 
   release-candidate-gate:
-    name: Approve Fully Validated Candidate
+    name: Approve Release Artifacts
     runs-on: ubuntu-latest
-    needs: [validate-and-prepare, candidate-ci, build-binaries, download-circuits]
+    needs: [validate-and-prepare, build-binaries, download-circuits]
     steps:
       - name: Confirm candidate qualification
-        run: echo "Candidate ${{ needs.validate-and-prepare.outputs.candidate_sha }} passed full CI and artifact checks."
+        run: echo "Candidate ${{ needs.validate-and-prepare.outputs.candidate_sha }} is on main and passed release artifact checks."
 
   publication-gate:
     name: Verify Every Release Publication

--- a/README.md
+++ b/README.md
@@ -348,11 +348,10 @@ pnpm release:tag 1.0.0-beta.1
 
 ### What the Release Workflow Requires
 
-The tag starts a new full CI run for the exact tagged commit. Path filters are disabled for this
-run. Publication cannot start until these checks succeed:
+The tag workflow does not repeat the repository CI that qualified the merged `main` commit.
+Publication cannot start until these release checks succeed:
 
 - The tag points to a commit in `origin/main`.
-- Every regular CI job passes, including CRISP and recovery tests.
 - Linux and Apple Silicon binaries build.
 - The `circuit-artifacts` branch contains the complete source-matched release matrix.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,7 +88,6 @@ pnpm release:tag X.Y.Z
 The tag workflow then:
 
 - Confirms that the tag belongs to `origin/main`.
-- Runs every CI job for the exact tagged commit.
 - Requires the binaries and source-matched circuit archive.
 - Publishes versioned containers and npm packages.
 - Creates the GitHub release only after every required publication succeeds.

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -105,12 +105,19 @@ describe('npm publication recovery', () => {
       remoteMissing: false,
       tagVersion: '1.2.3',
       viewError: '',
+      packOutput: [
+        {
+          filename: 'release-test-1.2.3.tgz',
+          integrity: 'sha512-candidate',
+          name: '@interfold/release-test',
+        },
+      ],
     }
     const execute = (_command, args, cwd) => {
       switch (args[0]) {
         case 'pack':
           writeFileSync(join(cwd, 'release-test-1.2.3.tgz'), '')
-          return result('[{"filename":"release-test-1.2.3.tgz","integrity":"sha512-candidate"}]\n')
+          return result(`${JSON.stringify(state.packOutput)}\n`)
         case 'view':
           if (state.viewError) return result('', 1, state.viewError)
           if (args[2] === 'dist.integrity') {
@@ -134,6 +141,21 @@ describe('npm publication recovery', () => {
 
   test('skips matching bytes that already have the requested tag', () => {
     const { execute, packageDir, rootDir, state } = fixture()
+    assert.equal(publishNpmPackage(packageDir, 'latest', { execute, rootDir }), 'skipped')
+    assert.equal(state.published, false)
+    assert.equal(existsSync(join(packageDir, 'release-test-1.2.3.tgz')), false)
+  })
+
+  test('accepts npm 12 package-keyed pack output', () => {
+    const { execute, packageDir, rootDir, state } = fixture()
+    state.packOutput = {
+      '@interfold/release-test': {
+        filename: 'release-test-1.2.3.tgz',
+        integrity: 'sha512-candidate',
+        name: '@interfold/release-test',
+      },
+    }
+
     assert.equal(publishNpmPackage(packageDir, 'latest', { execute, rootDir }), 'skipped')
     assert.equal(state.published, false)
     assert.equal(existsSync(join(packageDir, 'release-test-1.2.3.tgz')), false)

--- a/scripts/release/gates.mjs
+++ b/scripts/release/gates.mjs
@@ -58,10 +58,14 @@ export function checkReleaseSafeguards(rootDir = ROOT_DIR) {
   requireText(release, 'node scripts/release.mjs prepare', 'the release tag is not bound to main history')
   requireText(release, 'group: release-promotion-${{ github.repository }}', 'release promotions can overlap')
 
-  for (const unsafeText of ['continue-on-error: true', 'cachix/cachix-action', 'cargo workspaces publish']) {
+  for (const unsafeText of ['continue-on-error: true', 'cachix/cachix-action', 'cargo workspaces publish', 'npm@latest']) {
     if (release.includes(unsafeText)) {
       fail(`release workflow contains unsafe operation: ${unsafeText}`)
     }
+  }
+
+  if (!/^  NPM_VERSION: '\d+\.\d+\.\d+'$/m.test(release)) {
+    fail('release workflow does not pin an exact npm version')
   }
 
   for (const publisher of ['build-ciphernode-image-release', 'build-e3-support-release', 'publish-npm-packages']) {
@@ -71,6 +75,11 @@ export function checkReleaseSafeguards(rootDir = ROOT_DIR) {
   requireText(release, 'Required circuit-artifacts branch is missing', 'missing circuit artifacts do not fail closed')
   requireText(release, 'if-no-files-found: error', 'missing release archives do not fail artifact upload')
   requireText(release, 'node scripts/release.mjs publish-npm', 'npm publication cannot resume safely')
+  requireText(
+    jobSource(release, 'publish-npm-packages'),
+    'npm install -g "npm@${NPM_VERSION}"',
+    'npm publication does not install the pinned npm version',
+  )
 
   const createRelease = jobSource(release, 'create-github-release')
   requireText(createRelease, 'publication-gate', 'GitHub release creation does not require all publications')

--- a/scripts/release/gates.mjs
+++ b/scripts/release/gates.mjs
@@ -42,21 +42,16 @@ function requireText(source, text, message) {
 }
 
 export function checkReleaseSafeguards(rootDir = ROOT_DIR) {
-  const ci = readFileSync(join(rootDir, '.github/workflows/ci.yml'), 'utf8')
   const release = readFileSync(join(rootDir, '.github/workflows/releases.yml'), 'utf8')
   const bump = readFileSync(join(rootDir, 'scripts/bump-versions.ts'), 'utf8')
   const packageJson = readJson(rootDir, 'package.json')
 
-  requireText(ci, 'workflow_call:', 'the release workflow cannot call CI')
-  requireText(
-    ci,
-    `FORCE="\${{ github.event_name == 'workflow_dispatch' || inputs.release_candidate }}"`,
-    'release candidate CI does not force every path-filtered job',
-  )
-  requireText(release, 'uses: ./.github/workflows/ci.yml', 'the release does not test its exact tagged commit')
-  requireText(release, 'release_candidate: true', 'the release does not run complete CI')
   requireText(release, 'node scripts/release.mjs prepare', 'the release tag is not bound to main history')
   requireText(release, 'group: release-promotion-${{ github.repository }}', 'release promotions can overlap')
+
+  if (release.includes('uses: ./.github/workflows/ci.yml')) {
+    fail('release workflow repeats CI that already qualified the main commit')
+  }
 
   for (const unsafeText of ['continue-on-error: true', 'cachix/cachix-action', 'cargo workspaces publish', 'npm@latest']) {
     if (release.includes(unsafeText)) {
@@ -71,6 +66,11 @@ export function checkReleaseSafeguards(rootDir = ROOT_DIR) {
   for (const publisher of ['build-ciphernode-image-release', 'build-e3-support-release', 'publish-npm-packages']) {
     requireText(jobSource(release, publisher), 'release-candidate-gate', `${publisher} can publish before candidate qualification`)
   }
+
+  const candidateGate = jobSource(release, 'release-candidate-gate')
+  requireText(candidateGate, 'validate-and-prepare', 'release artifacts are not bound to the validated main commit')
+  requireText(candidateGate, 'build-binaries', 'publication can start without release binaries')
+  requireText(candidateGate, 'download-circuits', 'publication can start without source-matched circuits')
 
   requireText(release, 'Required circuit-artifacts branch is missing', 'missing circuit artifacts do not fail closed')
   requireText(release, 'if-no-files-found: error', 'missing release archives do not fail artifact upload')

--- a/scripts/release/npm.mjs
+++ b/scripts/release/npm.mjs
@@ -27,6 +27,18 @@ function isMissingNpmPackage(result) {
   return result.status !== 0 && /(?:E404|404 Not Found|is not in this registry)/i.test(`${result.stdout}\n${result.stderr}`)
 }
 
+function packedArchive(packed, packageName) {
+  if (Array.isArray(packed)) {
+    return packed.find((entry) => entry?.name === packageName) ?? packed[0]
+  }
+
+  if (packed && typeof packed === 'object') {
+    return packed[packageName]
+  }
+
+  return undefined
+}
+
 export function publishNpmPackage(packageDirectory, distTag, options = {}) {
   if (!['latest', 'next'].includes(distTag)) {
     fail(`refusing unsupported npm distribution tag: ${distTag}`)
@@ -38,7 +50,7 @@ export function publishNpmPackage(packageDirectory, distTag, options = {}) {
   const packageJson = readJson(packageDir, 'package.json')
   const packageSpec = `${packageJson.name}@${packageJson.version}`
   const packed = JSON.parse(runChecked(execute, 'npm', ['pack', '--json'], packageDir))
-  const { filename, integrity: localIntegrity } = packed[0] ?? {}
+  const { filename, integrity: localIntegrity } = packedArchive(packed, packageJson.name) ?? {}
 
   if (!filename || !localIntegrity) {
     fail(`npm pack did not return an archive and integrity for ${packageSpec}`)


### PR DESCRIPTION
Fix the npm publication failure from the v0.14.0 release attempt and remove redundant full-CI reruns from tag publication.

Root cause:
- The workflow installed `npm@latest`.
- npm 12 changed `npm pack --json` from an array to a package-keyed object.
- The resumable publisher only accepted the older array format.

Changes:
- Pin npm to `11.19.1`, which supports npm trusted publishing.
- Accept the npm 11 and npm 12 pack formats.
- Test both formats.
- Reject `npm@latest` or a missing exact npm pin.
- Do not rerun the repository CI after tagging a commit already merged into `main`.
- Keep release-specific ancestry, binary, circuit, publication, and promotion gates.

Validation:
- `pnpm test:release`
- `node scripts/release.mjs check`
- Actual `npm pack --json` with npm 11.19.1 and npm 12.0.2
- Full pre-push checks for the npm fix
- Focused release checks after removing duplicate tag CI

No package version changes are required. No npm package or GitHub release was published by the failed run.

[skip-line-limit]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm package publishing compatibility with newer npm output formats, including npm 12.
  * Added safeguards to ensure release artifacts and package publication use the required npm version and validation checks.

* **Documentation**
  * Updated release workflow documentation to clarify that publication relies on validated release artifacts rather than repeating the full CI suite.
  * Removed outdated guidance about running full CI for tagged releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->