### PR TITLE
chore(crisp): ship dual-preset sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,26 +189,26 @@ pnpm test:integration --no-prebuild
 				</a>
 			</td>
 			<td align="center">
+				<a href="https://github.com/eccogrinder">
+					<img src="https://avatars.githubusercontent.com/u/100447090?v=4" width="100;" alt="eccogrinder"/>
+					<br />
+					<sub><b>marv</b></sub>
+				</a>
+			</td>
+			<td align="center">
 				<a href="https://github.com/0xkeygen">
 					<img src="https://avatars.githubusercontent.com/u/211014662?v=4" width="100;" alt="0xkeygen"/>
 					<br />
 					<sub><b>Bryant</b></sub>
 				</a>
 			</td>
+		</tr>
+		<tr>
 			<td align="center">
 				<a href="https://github.com/zahrajavar">
 					<img src="https://avatars.githubusercontent.com/u/81833289?v=4" width="100;" alt="zahrajavar"/>
 					<br />
 					<sub><b>Zara</b></sub>
-				</a>
-			</td>
-		</tr>
-		<tr>
-			<td align="center">
-				<a href="https://github.com/eccogrinder">
-					<img src="https://avatars.githubusercontent.com/u/100447090?v=4" width="100;" alt="eccogrinder"/>
-					<br />
-					<sub><b>marv</b></sub>
 				</a>
 			</td>
 			<td align="center">

--- a/examples/CRISP/RELEASING.md
+++ b/examples/CRISP/RELEASING.md
@@ -1,31 +1,35 @@
 # Releasing the CRISP packages
 
-`@crisp-e3/sdk` and `@crisp-e3/contracts` are published as a matched pair on two channels, split by
-BFV preset.
+`@crisp-e3/sdk` and `@crisp-e3/contracts` are published as a matched pair on two channels.
 
 | channel    | tag       | preset         | who it is for                      |
 | ---------- | --------- | -------------- | ---------------------------------- |
 | testing    | `testing` | `insecure-512` | testnets, demos, local development |
-| production | `latest`  | `secure-8192`  | real rounds                        |
+| production | `latest`  | both presets   | deployed clients and real rounds   |
 
-## Why the channels are split by preset
+## Why presets are separate entry points
 
 The SDK inlines the compiled circuit and the contracts package ships the Solidity verifier generated
 from that same circuit's verification key. A verifier only accepts proofs from the circuit it was
 generated for, so mixing presets across the two packages produces a round that rejects every ballot
 — and it fails at on-chain verification, not anywhere a test would catch it.
 
-Each tarball therefore carries exactly one preset. Importing the other subpath fails to resolve,
-which is a loud, immediate error rather than a silently wrong proof:
+Each preset is a separate SDK subpath. The production package carries both subpaths so one client
+can read the E3's on-chain `paramSet` and load the matching preset. The testing package carries only
+the insecure preset so local and testnet installs stay small.
 
 ```ts
 // on @crisp-e3/sdk@testing
 import { loadCircuits } from '@crisp-e3/sdk/insecure-512' // resolves
 import { loadCircuits } from '@crisp-e3/sdk/secure-8192' // ERR_MODULE_NOT_FOUND
+
+// on @crisp-e3/sdk@latest
+import { loadCircuits as loadInsecure } from '@crisp-e3/sdk/insecure-512'
+import { loadCircuits as loadSecure } from '@crisp-e3/sdk/secure-8192'
 ```
 
-It also keeps the secure circuits out of every testing install. They are far larger than the
-insecure ones, and shipping both would put that weight in both channels.
+This keeps the secure circuits out of testing installs while making the production client flexible
+enough for secure mainnet rounds and insecure test deployments.
 
 ## Versioning
 
@@ -33,30 +37,29 @@ Testing releases carry a prerelease identifier; production releases do not.
 
 ```
 0.18.0-insecure.0   tag: testing    insecure-512
-0.18.0              tag: latest     secure-8192
+0.20.0              tag: latest     insecure-512 + secure-8192
 ```
 
 The identifier is load-bearing. npm excludes prerelease versions from ordinary ranges, so a consumer
 on `^0.18.0` can never drift onto a testing build through an update — reaching it takes an explicit
 `@testing` or an exact version.
 
-## The client stays on testing
+## The client tracks production
 
-`client/` is deployed against a testnet whose verifiers were deployed from `insecure-512` circuits,
-so it always pins a testing version. Only a testing publish moves it; a production publish leaves
-`client/package.json` and `client/pnpm-lock.yaml` untouched, and refuses to run at all if something
-else has moved the pin onto a plain release version.
+`client/` reads the E3 `paramSet` before proving and loads the matching preset. Because production
+SDK releases carry both presets, a production publish moves `client/package.json` and
+`client/pnpm-lock.yaml` to the published version. A testing publish leaves the client alone.
 
 The pin cannot be a `workspace:` range, because the same `client/package.json` also serves the
 standalone Vercel deploy, which installs with `ignore-workspace=true` (see `client/.npmrc`) and
 cannot resolve one. So it is an exact version, and that has a consequence worth stating plainly:
 
 **`linkWorkspacePackages: true` links `packages/crisp-sdk` only while its version still satisfies
-that exact pin.** Bump the workspace to `0.18.0` while the client pins `0.18.0-insecure.0` and pnpm
-stops linking and resolves the client from the registry instead. That is not a cosmetic difference.
-It re-resolves the whole client dependency tree (it pulled `zod@4` in place of `zod@3` across
-`viem`, `wagmi`, and `connectkit`), and it makes Vite pre-bundle the SDK as an ordinary dependency,
-which breaks the worker subpath:
+that exact pin.** Bump the workspace to `0.20.0` while the client pins `0.19.1` and pnpm stops
+linking and resolves the client from the registry instead. That is not a cosmetic difference. It
+re-resolves the whole client dependency tree (it pulled `zod@4` in place of `zod@3` across `viem`,
+`wagmi`, and `connectkit`), and it makes Vite pre-bundle the SDK as an ordinary dependency, which
+breaks the worker subpath:
 
 ```
 The file does not exist at ".../client/node_modules/.vite/deps/
@@ -64,12 +67,9 @@ workers/generateCircuitInputs.worker.js?worker_file&type=module"
 → [generateProof] failed → the e2e vote never reaches the wallet signature
 ```
 
-This is why a production publish restores the versions it bumped instead of committing them, and why
-`bumpsRepo` in `publish.ts` is tied to `tracksClient` rather than being independently selectable. A
-published version lives on npm; it does not need to live in the working tree.
-
-Moving the client to a production version is a deliberate change, made together with the redeploy
-that gives it `secure-8192` verifiers to prove against.
+This is why a production publish leaves the CRISP workspace packages and the client on the same
+exact version. A testing publish restores the versions it touched because the deployable client does
+not track the testing channel.
 
 ## Procedure
 
@@ -85,29 +85,29 @@ that `stage-preset-artifacts.mjs` records at staging time.
 ```sh
 pnpm -C examples/CRISP build:presets # slow: compiles both presets
 
-# testing — insecure-512 under the `testing` tag, and moves the client
+# testing — insecure-512 under the `testing` tag, leaves the client alone
 pnpm -C examples/CRISP publish:packages --channel testing 0.19.0-insecure.0
 
-# production — secure-8192 under the `latest` tag, and leaves the client alone
-pnpm -C examples/CRISP publish:packages --channel prod 0.19.0
+# production — both presets under the `latest` tag, and moves the client
+pnpm -C examples/CRISP publish:packages --channel prod 0.20.0
 ```
 
 Add `--dry-run` to print the exact steps for a channel without changing anything. The script bumps
-all three packages, builds the SDK against the channel's preset, and publishes in dependency order
-(`zk-inputs`, `sdk`, `contracts`). It never tags and never pushes.
+all three packages, builds the SDK against the channel's preset set, and publishes in dependency
+order (`zk-inputs`, `sdk`, `contracts`). It never tags and never pushes.
 
-What it leaves behind differs by channel. Testing commits the bump. Production restores it, so the
-tree ends exactly as it started — see "The client stays on testing" above for why. Either way, a
-failure at any point restores the tree too: a half-bumped workspace is worse than no bump, because
-the next `pnpm install` silently detaches the client from it.
+What it leaves behind differs by channel. Production commits the bump so the tree and client stay on
+the production version. Testing restores the version bump because the deployable client does not
+track the testing channel. Either way, a failure restores the tree: a half-bumped workspace is worse
+than no bump, because the next `pnpm install` silently detaches the client from it.
 
 Two gates run on the way:
 
 - `check-staged-preset.mjs` (in `build:testing` / `build:prod`) refuses staged artifacts the
   circuits have moved past.
 - `check-presets.mjs` (`prepublishOnly` on both packages) refuses to publish a channel whose
-  artifacts do not match its preset — a missing preset, a stub bundle, an exports entry pointing at
-  nothing, missing verifiers, or the _other_ preset's bundle being present.
+  artifacts do not match its preset set — a missing preset, a stub bundle, an exports entry pointing
+  at nothing, missing verifiers, or an unexpected preset bundle.
 
 ## Deploying
 
@@ -115,9 +115,8 @@ Generated aggregator verifiers are preset-specific and committee-specific. The p
 concrete PK and decryption verifier for each supported pair. A router selects the concrete verifier
 from the proof's public-input length and VK hash anchors.
 
-The SDK must also match the round. Pair a `latest` SDK with a `secure-8192` deployment. Pair a
-`testing` SDK with an `insecure-512` deployment. The testnet client reads `paramSet` from the E3
-before it proves and rejects a secure round with a directed error.
+The SDK must also match the round. A `latest` SDK can load either supported preset and should select
+from the E3's on-chain `paramSet`. Pair a `testing` SDK only with `insecure-512` deployments.
 
 For an existing paused mainnet bootstrap deployment, prepare the complete activation batch with:
 

--- a/examples/CRISP/RELEASING.md
+++ b/examples/CRISP/RELEASING.md
@@ -35,7 +35,7 @@ enough for secure mainnet rounds and insecure test deployments.
 
 Testing releases carry a prerelease identifier; production releases do not.
 
-```
+```text
 0.18.0-insecure.0   tag: testing    insecure-512
 0.20.0              tag: latest     insecure-512 + secure-8192
 ```
@@ -61,7 +61,7 @@ re-resolves the whole client dependency tree (it pulled `zod@4` in place of `zod
 `wagmi`, and `connectkit`), and it makes Vite pre-bundle the SDK as an ordinary dependency, which
 breaks the worker subpath:
 
-```
+```text
 The file does not exist at ".../client/node_modules/.vite/deps/
 workers/generateCircuitInputs.worker.js?worker_file&type=module"
 → [generateProof] failed → the e2e vote never reaches the wallet signature
@@ -77,19 +77,16 @@ Publish through `scripts/publish.ts`. It selects the preset from the release cha
 packages, publishes in dependency order, and updates the standalone client lockfile after npm serves
 the new SDK version.
 
-Both channels build from the artifacts that `pnpm build:presets` archives under
-`circuits/dist/<preset>/`, which git does not track. Run that command whenever the circuits change.
-The SDK build refuses artifacts that are missing or older than the sources, using the content digest
+SDK builds stage their required artifacts under `circuits/dist/<preset>/`, which git does not track.
+The build refuses artifacts that are missing or older than the sources, using the content digest
 that `stage-preset-artifacts.mjs` records at staging time.
 
-The default SDK build is intentionally the lightweight testing build. It ships only `insecure-512`
-so pull-request CI does not compile or bundle the large secure preset. Use the production channel,
-or `pnpm -C examples/CRISP/packages/crisp-sdk build:prod`, when the output must include both
-`insecure-512` and `secure-8192`.
+The default SDK build is intentionally the lightweight testing build. It builds and ships only
+`insecure-512` so pull-request CI does not compile or bundle the large secure preset. Use the
+production channel, or `pnpm -C examples/CRISP/packages/crisp-sdk build:prod`, when the output must
+include both `insecure-512` and `secure-8192`.
 
 ```sh
-pnpm -C examples/CRISP build:presets # slow: compiles both presets
-
 # testing — insecure-512 under the `testing` tag, leaves the client alone
 pnpm -C examples/CRISP publish:packages --channel testing 0.19.0-insecure.0
 

--- a/examples/CRISP/RELEASING.md
+++ b/examples/CRISP/RELEASING.md
@@ -16,12 +16,14 @@ generated for, so mixing presets across the two packages produces a round that r
 
 Each preset is a separate SDK subpath. The production package carries both subpaths so one client
 can read the E3's on-chain `paramSet` and load the matching preset. The testing package carries only
-the insecure preset so local and testnet installs stay small.
+the real insecure preset so local and testnet installs stay small. It also ships tiny stubs for the
+other exported subpaths, so bundlers can resolve the client import graph without bundling secure
+circuits into test builds.
 
 ```ts
 // on @crisp-e3/sdk@testing
 import { loadCircuits } from '@crisp-e3/sdk/insecure-512' // resolves
-import { loadCircuits } from '@crisp-e3/sdk/secure-8192' // ERR_MODULE_NOT_FOUND
+import { loadCircuits } from '@crisp-e3/sdk/secure-8192' // resolves, throws if called
 
 // on @crisp-e3/sdk@latest
 import { loadCircuits as loadInsecure } from '@crisp-e3/sdk/insecure-512'
@@ -81,10 +83,11 @@ SDK builds stage their required artifacts under `circuits/dist/<preset>/`, which
 The build refuses artifacts that are missing or older than the sources, using the content digest
 that `stage-preset-artifacts.mjs` records at staging time.
 
-The default SDK build is intentionally the lightweight testing build. It builds and ships only
-`insecure-512` so pull-request CI does not compile or bundle the large secure preset. Use the
-production channel, or `pnpm -C examples/CRISP/packages/crisp-sdk build:prod`, when the output must
-include both `insecure-512` and `secure-8192`.
+The default SDK build is intentionally the lightweight testing build. It builds and ships only the
+real `insecure-512` bundle, plus resolver stubs for off-channel presets, so pull-request CI does not
+compile or bundle the large secure preset. Use the production channel, or
+`pnpm -C examples/CRISP/packages/crisp-sdk build:prod`, when the output must include real
+`insecure-512` and `secure-8192` bundles.
 
 ```sh
 # testing — insecure-512 under the `testing` tag, leaves the client alone
@@ -108,8 +111,8 @@ Two gates run on the way:
 - `check-staged-preset.mjs` (in `build:testing` / `build:prod`) refuses staged artifacts the
   circuits have moved past.
 - `check-presets.mjs` (`prepublishOnly` on both packages) refuses to publish a channel whose
-  artifacts do not match its preset set — a missing preset, a stub bundle, an exports entry pointing
-  at nothing, missing verifiers, or an unexpected preset bundle.
+  artifacts do not match its preset set — a missing preset, a wanted preset that is only a stub, an
+  exports entry pointing at nothing, missing verifiers, or an unexpected real preset bundle.
 
 ## Deploying
 

--- a/examples/CRISP/RELEASING.md
+++ b/examples/CRISP/RELEASING.md
@@ -82,6 +82,11 @@ Both channels build from the artifacts that `pnpm build:presets` archives under
 The SDK build refuses artifacts that are missing or older than the sources, using the content digest
 that `stage-preset-artifacts.mjs` records at staging time.
 
+The default SDK build is intentionally the lightweight testing build. It ships only `insecure-512`
+so pull-request CI does not compile or bundle the large secure preset. Use the production channel,
+or `pnpm -C examples/CRISP/packages/crisp-sdk build:prod`, when the output must include both
+`insecure-512` and `secure-8192`.
+
 ```sh
 pnpm -C examples/CRISP build:presets # slow: compiles both presets
 

--- a/examples/CRISP/client/package.json
+++ b/examples/CRISP/client/package.json
@@ -12,13 +12,13 @@
     "cli": "pnpm sh ./scripts/cli.sh",
     "dev": "vite --no-open --host",
     "dev-static": "NO_HOT=1 vite --no-open --host",
-    "build": "tsc && vite build",
+    "build": "tsc && NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "preview": "vite preview",
     "predeploy": "pnpm run build",
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "@crisp-e3/sdk": "0.18.0-insecure.0",
+    "@crisp-e3/sdk": "0.20.0",
     "@emotion/babel-plugin": "^11.11.0",
     "@emotion/react": "^11.11.4",
     "@phosphor-icons/react": "^2.1.4",

--- a/examples/CRISP/client/pnpm-lock.yaml
+++ b/examples/CRISP/client/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   .:
     dependencies:
       '@crisp-e3/sdk':
-        specifier: 0.18.0-insecure.0
-        version: 0.18.0-insecure.0(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 0.20.0
+        version: 0.20.0(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@emotion/babel-plugin':
         specifier: ^11.11.0
         version: 11.13.5
@@ -733,11 +733,11 @@ packages:
   '@coinbase/wallet-sdk@4.3.6':
     resolution: {integrity: sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==}
 
-  '@crisp-e3/sdk@0.18.0-insecure.0':
-    resolution: {integrity: sha512-1qwFF8sR1VDDoSH178gr+DzluMThGhdCNpx9SsMJLC+gpPlU8A7qKThNv1P7hxaMB12q15so6KJumhL7euf7Gg==}
+  '@crisp-e3/sdk@0.20.0':
+    resolution: {integrity: sha512-3CrnI5eJ7ia0AeWtg6l7byAZEvXCx7ZSW8nB6WiAseDOiuO8IqtN3ax2cu8t6KhvRG2lAKQz6VON7ljiqDsh9A==}
 
-  '@crisp-e3/zk-inputs@0.18.0-insecure.0':
-    resolution: {integrity: sha512-vgIb8cixmxeLTYEfvmKlzGzMDQg1/Y1xc9wIcSrlDBZRxEdHz3bpnBV59GPVCG4Fx5obXHKDvILhyIdT2n8Nqw==}
+  '@crisp-e3/zk-inputs@0.20.0':
+    resolution: {integrity: sha512-pAup/xUdCGZ/8l4DcQAVToVV0Azh2xpzsKme5BsB4S5ggjeJ+k7mwA6WXO3aUIOtipWfHVRTU1cZ7x4mN/Fp7w==}
 
   '@ecies/ciphers@0.2.6':
     resolution: {integrity: sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==}
@@ -5635,10 +5635,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@crisp-e3/sdk@0.18.0-insecure.0(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@crisp-e3/sdk@0.20.0(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@aztec/bb.js': 5.1.0
-      '@crisp-e3/zk-inputs': 0.18.0-insecure.0
+      '@crisp-e3/zk-inputs': 0.20.0
       '@noir-lang/noir_js': 1.0.0-beta.26
       '@zk-kit/lean-imt': 2.2.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       poseidon-lite: 0.3.0
@@ -5649,7 +5649,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@crisp-e3/zk-inputs@0.18.0-insecure.0': {}
+  '@crisp-e3/zk-inputs@0.20.0': {}
 
   '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
     dependencies:

--- a/examples/CRISP/client/src/utils/circuits.ts
+++ b/examples/CRISP/client/src/utils/circuits.ts
@@ -5,46 +5,53 @@
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
 import { registeredPreset, setCircuits } from '@crisp-e3/sdk'
+import type { CircuitBundle, CircuitPreset } from '@crisp-e3/sdk'
 
-// The BFV-shaped circuits are ~2.9MB and ship as their own entry point per preset. Loading them
+// The BFV-shaped circuits ship as their own entry point per preset. Loading them
 // through a dynamic import gives the bundler a split point, so the app boots on the ~350KB main
 // entry and only pays for the circuits when someone actually votes.
 //
-// This testnet client carries only the insecure preset. Production clients install the `latest`
-// SDK release and import its secure preset instead. Check the round before proving so a deployment
-// mismatch fails here instead of producing a proof that the on-chain verifier rejects.
-let pending: Promise<void> | null = null
+// The production SDK carries both presets. The E3 stores the selected param set on chain, so the
+// client selects the matching circuits before proving instead of hardcoding one deployment mode.
+const LOADERS: Record<CircuitPreset, () => Promise<{ loadCircuits: () => Promise<CircuitBundle> }>> = {
+  'insecure-512': () => import('@crisp-e3/sdk/insecure-512'),
+  'secure-8192': () => import('@crisp-e3/sdk/secure-8192'),
+}
+
+let pending: Partial<Record<CircuitPreset, Promise<void>>> = {}
+
+const presetForParamSet = (paramSet: number): CircuitPreset | null => {
+  if (paramSet === 0) return 'insecure-512'
+  if (paramSet === 1) return 'secure-8192'
+  return null
+}
 
 /** Install the circuits needed for proving, at most once per session. */
 export const ensureCircuits = async (paramSet: number): Promise<void> => {
-  if (paramSet !== 0) {
-    throw new Error(
-      `This CRISP client carries insecure-512 circuits, but E3 param set ${paramSet} requires secure-8192. Use the production client built with @crisp-e3/sdk@latest.`,
-    )
+  const expectedPreset = presetForParamSet(paramSet)
+  if (!expectedPreset) {
+    throw new Error(`Unsupported E3 param set ${paramSet}.`)
   }
 
   const activePreset = registeredPreset()
-  if (activePreset) {
-    if (activePreset !== 'insecure-512') {
-      throw new Error(`The registered ${activePreset} circuits do not match E3 param set ${paramSet}.`)
-    }
+  if (activePreset === expectedPreset) {
     return
   }
 
-  pending ??= (async () => {
+  const load = (pending[expectedPreset] ??= (async () => {
     try {
-      const { loadCircuits } = await import('@crisp-e3/sdk/insecure-512')
+      const { loadCircuits } = await LOADERS[expectedPreset]()
       setCircuits(await loadCircuits())
     } catch (error) {
       // Let the next attempt retry rather than caching a failed fetch for the session.
-      pending = null
+      delete pending[expectedPreset]
       throw error
     }
-  })()
+  })())
 
-  await pending
+  await load
 
-  if (registeredPreset() !== 'insecure-512') {
-    throw new Error('The loaded circuit bundle does not match E3 param set 0.')
+  if (registeredPreset() !== expectedPreset) {
+    throw new Error(`The loaded circuit bundle does not match E3 param set ${paramSet}.`)
   }
 }

--- a/examples/CRISP/client/src/utils/circuits.ts
+++ b/examples/CRISP/client/src/utils/circuits.ts
@@ -39,17 +39,18 @@ export const ensureCircuits = async (paramSet: number): Promise<void> => {
   }
 
   const load = (pending[expectedPreset] ??= (async () => {
-    try {
-      const { loadCircuits } = await LOADERS[expectedPreset]()
-      setCircuits(await loadCircuits())
-    } catch (error) {
-      // Let the next attempt retry rather than caching a failed fetch for the session.
-      delete pending[expectedPreset]
-      throw error
-    }
+    const { loadCircuits } = await LOADERS[expectedPreset]()
+    setCircuits(await loadCircuits())
   })())
 
-  await load
+  try {
+    await load
+  } finally {
+    // Cache only in-flight loads. A later preset switch must rerun setCircuits().
+    if (pending[expectedPreset] === load) {
+      delete pending[expectedPreset]
+    }
+  }
 
   if (registeredPreset() !== expectedPreset) {
     throw new Error(`The loaded circuit bundle does not match E3 param set ${paramSet}.`)

--- a/examples/CRISP/packages/crisp-contracts/package.json
+++ b/examples/CRISP/packages/crisp-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crisp-e3/contracts",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "type": "module",
   "files": [
     "contracts",

--- a/examples/CRISP/packages/crisp-sdk/README.md
+++ b/examples/CRISP/packages/crisp-sdk/README.md
@@ -16,13 +16,13 @@ npm install @crisp-e3/sdk
 - **Merkle Tree Utilities**: Generate proofs for voter inclusion in the eligibility tree
 - **Vote Proof Generation**: Create zero-knowledge proofs for votes and mask votes
 - **Proof Verification**: Verify generated proofs using Noir circuits
-- **Selectable Parameters**: each release channel ships one preset as a separate entry point
+- **Selectable Parameters**: preset bundles are separate entry points and can be loaded on demand
 
 ## Choosing a preset
 
 Proving needs the BFV-shaped circuits, and those exist once per parameter set. They are not part of
-the main entry point: the `secure-8192` set is far larger than `insecure-512`, and no consumer needs
-both. Each release channel ships one preset subpath, so your bundler pulls only the one you import.
+the main entry point: the `secure-8192` set is far larger than `insecure-512`. Each preset has its
+own subpath, so your bundler can pull only the one the round needs.
 
 ```ts
 import { setCircuits } from '@crisp-e3/sdk'
@@ -39,7 +39,7 @@ In a browser, load it through a dynamic `import()` so the circuits become their 
 app boots without them:
 
 ```ts
-const { loadCircuits } = await import('@crisp-e3/sdk/insecure-512')
+const { loadCircuits } = await import('@crisp-e3/sdk/secure-8192')
 setCircuits(await loadCircuits())
 ```
 

--- a/examples/CRISP/packages/crisp-sdk/package.json
+++ b/examples/CRISP/packages/crisp-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@crisp-e3/sdk",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "type": "module",
   "author": {
     "name": "gnosisguild",
@@ -42,7 +42,7 @@
     "compile:fold": "cd ../../circuits/bin/fold && nargo compile",
     "compile:fold_onchain": "cd ../../circuits/bin/fold_onchain && nargo compile",
     "build:wasm": "pnpm -C ../crisp-zk-inputs build",
-    "build": "pnpm build:wasm && pnpm compile:circuits && pnpm stage:preset insecure-512 && tsup",
+    "build": "pnpm build:wasm && pnpm build:presets && tsup",
     "test": "pnpm stage:preset insecure-512 && vitest --run",
     "test:core-and-ballot-proofs": "pnpm stage:preset insecure-512 && vitest --run -t \"^(?!.*generateMaskVoteProof)\"",
     "test:mask-proofs": "pnpm stage:preset insecure-512 && vitest --run tests/vote.test.ts -t \"generateMaskVoteProof\"",
@@ -51,7 +51,7 @@
     "check:presets": "node ../../scripts/check-presets.mjs",
     "prepublishOnly": "pnpm check:presets",
     "build:testing": "pnpm build:wasm && pnpm check:staged insecure-512 && CRISP_PRESET=insecure-512 tsup",
-    "build:prod": "pnpm build:wasm && pnpm check:staged secure-8192 && CRISP_PRESET=secure-8192 tsup",
+    "build:prod": "pnpm build:wasm && pnpm check:staged insecure-512 && pnpm check:staged secure-8192 && tsup",
     "check:staged": "node ../../scripts/check-staged-preset.mjs"
   },
   "publishConfig": {

--- a/examples/CRISP/packages/crisp-sdk/package.json
+++ b/examples/CRISP/packages/crisp-sdk/package.json
@@ -42,7 +42,7 @@
     "compile:fold": "cd ../../circuits/bin/fold && nargo compile",
     "compile:fold_onchain": "cd ../../circuits/bin/fold_onchain && nargo compile",
     "build:wasm": "pnpm -C ../crisp-zk-inputs build",
-    "build": "pnpm build:wasm && pnpm build:presets && tsup",
+    "build": "pnpm build:testing",
     "test": "pnpm stage:preset insecure-512 && vitest --run",
     "test:core-and-ballot-proofs": "pnpm stage:preset insecure-512 && vitest --run -t \"^(?!.*generateMaskVoteProof)\"",
     "test:mask-proofs": "pnpm stage:preset insecure-512 && vitest --run tests/vote.test.ts -t \"generateMaskVoteProof\"",

--- a/examples/CRISP/packages/crisp-sdk/package.json
+++ b/examples/CRISP/packages/crisp-sdk/package.json
@@ -48,10 +48,11 @@
     "test:mask-proofs": "pnpm stage:preset insecure-512 && vitest --run tests/vote.test.ts -t \"generateMaskVoteProof\"",
     "stage:preset": "node ../../scripts/stage-preset-artifacts.mjs",
     "build:presets": "node ../../scripts/build-presets.mjs",
+    "build:presets:all": "node ../../scripts/build-presets.mjs --all",
     "check:presets": "node ../../scripts/check-presets.mjs",
     "prepublishOnly": "pnpm check:presets",
-    "build:testing": "pnpm build:wasm && pnpm check:staged insecure-512 && CRISP_PRESET=insecure-512 tsup",
-    "build:prod": "pnpm build:wasm && pnpm check:staged insecure-512 && pnpm check:staged secure-8192 && tsup",
+    "build:testing": "pnpm build:wasm && pnpm build:presets && pnpm check:staged insecure-512 && CRISP_PRESET=insecure-512 tsup",
+    "build:prod": "pnpm build:wasm && pnpm build:presets:all && pnpm check:staged insecure-512 && pnpm check:staged secure-8192 && tsup",
     "check:staged": "node ../../scripts/check-staged-preset.mjs"
   },
   "publishConfig": {

--- a/examples/CRISP/packages/crisp-sdk/src/circuits.ts
+++ b/examples/CRISP/packages/crisp-sdk/src/circuits.ts
@@ -32,8 +32,8 @@ let registered: CircuitBundle | null = null
  * Install the preset-bound circuits used by `generateProof`.
  *
  * The bundle is not bundled into the main entry point, because the secure-8192 artifacts are more
- * than an order of magnitude larger than the insecure-512 ones and no consumer needs both. Load the
- * one you want from its subpath and register it once at start-up:
+ * than an order of magnitude larger than the insecure-512 ones. Load the preset selected by the
+ * round from its subpath and register it before proving:
  *
  * ```ts
  * import { setCircuits } from '@crisp-e3/sdk'

--- a/examples/CRISP/packages/crisp-sdk/src/presets/insecure-512.unavailable.ts
+++ b/examples/CRISP/packages/crisp-sdk/src/presets/insecure-512.unavailable.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+import type { CircuitBundle, CircuitPreset } from '../circuits'
+
+export const preset: CircuitPreset = 'insecure-512'
+
+export const loadCircuits = async (): Promise<CircuitBundle> => {
+  throw new Error(
+    'The insecure-512 circuits are not included in this @crisp-e3/sdk build. ' +
+      'Install an SDK release channel that carries insecure-512.',
+  )
+}

--- a/examples/CRISP/packages/crisp-sdk/src/presets/secure-8192.unavailable.ts
+++ b/examples/CRISP/packages/crisp-sdk/src/presets/secure-8192.unavailable.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+import type { CircuitBundle, CircuitPreset } from '../circuits'
+
+export const preset: CircuitPreset = 'secure-8192'
+
+export const loadCircuits = async (): Promise<CircuitBundle> => {
+  throw new Error(
+    'The secure-8192 circuits are not included in this @crisp-e3/sdk build. ' +
+      'Install the production @crisp-e3/sdk release from the latest npm tag.',
+  )
+}

--- a/examples/CRISP/packages/crisp-sdk/tests/client-circuits.test.ts
+++ b/examples/CRISP/packages/crisp-sdk/tests/client-circuits.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+//
+// This file is provided WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const sdkState = vi.hoisted(() => ({
+  current: null as string | null,
+  loads: [] as string[],
+}))
+
+vi.mock('@crisp-e3/sdk', () => ({
+  registeredPreset: () => sdkState.current,
+  setCircuits: (bundle: { preset: string }) => {
+    sdkState.current = bundle.preset
+  },
+}))
+
+vi.mock('@crisp-e3/sdk/insecure-512', () => ({
+  loadCircuits: async () => {
+    sdkState.loads.push('insecure-512')
+    return { preset: 'insecure-512' }
+  },
+}))
+
+vi.mock('@crisp-e3/sdk/secure-8192', () => ({
+  loadCircuits: async () => {
+    sdkState.loads.push('secure-8192')
+    return { preset: 'secure-8192' }
+  },
+}))
+
+import { ensureCircuits } from '../../../client/src/utils/circuits'
+
+afterEach(() => {
+  sdkState.current = null
+  sdkState.loads = []
+})
+
+describe('client ensureCircuits', () => {
+  it('reloads a completed preset when switching back to it', async () => {
+    await ensureCircuits(0)
+    await ensureCircuits(1)
+    await ensureCircuits(0)
+
+    expect(sdkState.current).toBe('insecure-512')
+    expect(sdkState.loads).toEqual(['insecure-512', 'secure-8192', 'insecure-512'])
+  })
+})

--- a/examples/CRISP/packages/crisp-sdk/tsup.config.js
+++ b/examples/CRISP/packages/crisp-sdk/tsup.config.js
@@ -10,9 +10,11 @@ import { defineConfig } from 'tsup'
 // Each preset is its own entry point, so a consumer's bundler can load only the BFV-shaped circuits
 // the current round needs.
 //
-// `CRISP_PRESET` builds one preset. The testing channel uses that to keep the package lightweight.
-// With `CRISP_PRESET` unset, every staged preset becomes an entry point. Production releases use
-// that path so one client can serve both secure mainnet rounds and insecure testnet rounds.
+// `CRISP_PRESET` builds one real preset. The testing channel uses that to keep the package
+// lightweight, and emits resolver-safe stubs for the other exported preset subpaths.
+//
+// With `CRISP_PRESET` unset, every staged preset becomes a real entry point. Production releases
+// use that path so one client can serve both secure mainnet rounds and insecure testnet rounds.
 //
 // With `CRISP_PRESET` unset the build takes whatever is staged, which is what local development
 // wants.
@@ -26,6 +28,11 @@ if (requested !== undefined && !PRESETS.includes(requested)) {
 }
 
 let selected
+const entry = {
+  index: 'src/index.ts',
+  'workers/generateCircuitInputs.worker': 'src/workers/generateCircuitInputs.worker.ts',
+}
+
 if (requested === undefined) {
   selected = PRESETS.filter(staged)
   for (const preset of PRESETS) {
@@ -40,8 +47,12 @@ if (requested === undefined) {
   console.log(`tsup: building the ${requested} entry only (CRISP_PRESET).`)
 }
 
+for (const preset of PRESETS) {
+  entry[`presets/${preset}`] = selected.includes(preset) ? `src/presets/${preset}.ts` : `src/presets/${preset}.unavailable.ts`
+}
+
 export default defineConfig({
-  entry: ['src/index.ts', 'src/workers/generateCircuitInputs.worker.ts', ...selected.map((preset) => `src/presets/${preset}.ts`)],
+  entry,
   include: ['src/**/*.ts'],
   splitting: false,
   sourcemap: true,

--- a/examples/CRISP/packages/crisp-sdk/tsup.config.js
+++ b/examples/CRISP/packages/crisp-sdk/tsup.config.js
@@ -7,15 +7,12 @@
 import { existsSync } from 'node:fs'
 import { defineConfig } from 'tsup'
 
-// Each preset is its own entry point, so a consumer's bundler pulls one set of BFV-shaped circuits
-// rather than both.
+// Each preset is its own entry point, so a consumer's bundler can load only the BFV-shaped circuits
+// the current round needs.
 //
-// A published tarball carries exactly one preset, selected by `CRISP_PRESET`, because the release
-// channels are split by preset: `testing` ships insecure-512 and `latest` ships secure-8192. The
-// secure circuits are far larger than the insecure ones, and shipping both would put that weight in
-// every install of either. Importing the preset a tarball does not carry then fails to resolve,
-// which is the right failure — the alternative is proving against parameters the deployed verifier
-// does not match, and that is only discovered on chain.
+// `CRISP_PRESET` builds one preset. The testing channel uses that to keep the package lightweight.
+// With `CRISP_PRESET` unset, every staged preset becomes an entry point. Production releases use
+// that path so one client can serve both secure mainnet rounds and insecure testnet rounds.
 //
 // With `CRISP_PRESET` unset the build takes whatever is staged, which is what local development
 // wants.

--- a/examples/CRISP/packages/crisp-zk-inputs/package.json
+++ b/examples/CRISP/packages/crisp-zk-inputs/package.json
@@ -2,7 +2,7 @@
   "name": "@crisp-e3/zk-inputs",
   "type": "module",
   "description": "Core logic to pre-compute CRISP ZK inputs (WASM/JavaScript bindings).",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "license": "LGPL-3.0-only",
   "repository": {
     "type": "git",

--- a/examples/CRISP/scripts/build-presets.mjs
+++ b/examples/CRISP/scripts/build-presets.mjs
@@ -5,7 +5,7 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-// Compile and stage the CRISP circuits for every preset, so the SDK can publish both.
+// Compile and stage the CRISP circuits for the requested preset set.
 //
 // The preset is a global compile-time choice (circuits/lib/src/configs/default/mod.nr), so the
 // presets cannot be built concurrently — each pass switches the tree, compiles, and archives the
@@ -21,14 +21,34 @@ import { fileURLToPath } from 'node:url'
 
 const CRISP = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const REPO = resolve(CRISP, '..', '..')
+const ALL_PRESETS = ['secure-8192', 'insecure-512']
 
-/**
- * Insecure is built last so the working tree is left on the default preset.
- *
- * The default SDK build uses the insecure preset for CI speed, and production publishing uses the
- * archived preset outputs. Ending on the default preset keeps local tools predictable.
- */
-const PRESETS = ['secure-8192', 'insecure-512']
+const usage = () => {
+  console.error('Usage: build-presets.mjs [--preset insecure-512|secure-8192] [--all]')
+  console.error('Defaults to --preset insecure-512 for pull-request CI and local development.')
+}
+
+const args = process.argv.slice(2)
+let requested = 'insecure-512'
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i]
+  if (arg === '--all') {
+    requested = 'all'
+  } else if (arg === '--preset') {
+    requested = args[++i]
+  } else {
+    usage()
+    process.exit(1)
+  }
+}
+
+const PRESETS = requested === 'all' ? ALL_PRESETS : [requested]
+for (const preset of PRESETS) {
+  if (!ALL_PRESETS.includes(preset)) {
+    usage()
+    process.exit(1)
+  }
+}
 
 const run = (cmd, args, cwd) => {
   console.log(`   $ ${cmd} ${args.join(' ')}`)
@@ -53,5 +73,9 @@ for (const preset of PRESETS) {
 
 console.log(`\n✓ staged ${PRESETS.length} preset(s); tree left on ${PRESETS.at(-1)}`)
 console.log('  If the ballot circuits changed, regenerate the fold key hashes: scripts/compute_vk_hash.sh')
-console.log('  Then rebuild the production SDK: pnpm -C packages/crisp-sdk build:prod')
-console.log('  Then check it: CRISP_CHANNEL=latest pnpm -C packages/crisp-sdk check:presets')
+if (requested === 'all') {
+  console.log('  Then rebuild the production SDK: pnpm -C packages/crisp-sdk build:prod')
+  console.log('  Then check it: CRISP_CHANNEL=latest pnpm -C packages/crisp-sdk check:presets')
+} else {
+  console.log('  Then rebuild the testing SDK: pnpm -C packages/crisp-sdk build')
+}

--- a/examples/CRISP/scripts/build-presets.mjs
+++ b/examples/CRISP/scripts/build-presets.mjs
@@ -25,8 +25,8 @@ const REPO = resolve(CRISP, '..', '..')
 /**
  * Insecure is built last so the working tree is left on the default preset.
  *
- * A plain `pnpm build` in the SDK inlines whatever the tree currently holds, so ending on anything
- * else would quietly change what the next build produces.
+ * The default SDK build uses the insecure preset for CI speed, and production publishing uses the
+ * archived preset outputs. Ending on the default preset keeps local tools predictable.
  */
 const PRESETS = ['secure-8192', 'insecure-512']
 
@@ -53,4 +53,5 @@ for (const preset of PRESETS) {
 
 console.log(`\n✓ staged ${PRESETS.length} preset(s); tree left on ${PRESETS.at(-1)}`)
 console.log('  If the ballot circuits changed, regenerate the fold key hashes: scripts/compute_vk_hash.sh')
-console.log('  Then rebuild the SDK (pnpm -C packages/crisp-sdk build) and check: pnpm -C packages/crisp-sdk check:presets')
+console.log('  Then rebuild the production SDK: pnpm -C packages/crisp-sdk build:prod')
+console.log('  Then check it: CRISP_CHANNEL=latest pnpm -C packages/crisp-sdk check:presets')

--- a/examples/CRISP/scripts/check-presets.mjs
+++ b/examples/CRISP/scripts/check-presets.mjs
@@ -40,6 +40,13 @@ const EXPECTED_DEGREE = { 'insecure-512': 512, 'secure-8192': 8192 }
 /** Below this a "built" entry is a stub or a failed inline rather than a real circuit bundle. */
 const MIN_BYTES = 100 * 1024
 
+/** Above this an off-channel entry is probably a real circuit bundle rather than a resolver stub. */
+const MAX_STUB_BYTES = 10 * 1024
+
+// The bundler may emit the inlined JSON as a JS object literal, so the key can be quoted or bare
+// and the space is optional. Match all of those rather than one spelling.
+const hasDegree = (source, value) => new RegExp(`["']?length["']?\\s*:\\s*${value}\\b`).test(source)
+
 // npm gives `prepublishOnly` no way to see `--tag`, so the channel comes through the environment
 // when the publish scripts set it, and through argv when run by hand.
 const channel = process.argv[2] ?? process.env.CRISP_CHANNEL
@@ -82,8 +89,15 @@ for (const preset of wanted) {
 }
 
 for (const other of others) {
-  if (existsSync(join(SDK, 'dist', 'presets', `${other}.js`))) {
-    problems.push(`${other}: dist/presets/${other}.js must not ship on "${channel}".`)
+  const path = join(SDK, 'dist', 'presets', `${other}.js`)
+  if (!existsSync(path)) continue
+
+  const source = readFileSync(path, 'utf8')
+  const size = statSync(path).size
+  const containsKnownDegree = Object.values(EXPECTED_DEGREE).some((degree) => hasDegree(source, degree))
+
+  if (size > MAX_STUB_BYTES || containsKnownDegree) {
+    problems.push(`${other}: "${channel}" may ship only a resolver stub for off-channel presets, not a real circuit bundle.`)
   }
 }
 
@@ -100,15 +114,11 @@ for (const preset of wanted) {
   const degree = EXPECTED_DEGREE[preset]
   const unexpected = Object.entries(EXPECTED_DEGREE).filter(([candidate]) => candidate !== preset)
 
-  // The bundler may emit the inlined JSON as a JS object literal, so the key can be quoted or bare
-  // and the space is optional. Match all of those rather than one spelling.
-  const hasDegree = (value) => new RegExp(`["']?length["']?\\s*:\\s*${value}\\b`).test(source)
-
-  if (!hasDegree(degree)) {
+  if (!hasDegree(source, degree)) {
     problems.push(`${preset}: dist/presets/${preset}.js contains no length-${degree} arrays; the inlined circuits are not ${preset}.`)
   }
   for (const [otherPreset, otherDegree] of unexpected) {
-    if (hasDegree(otherDegree)) {
+    if (hasDegree(source, otherDegree)) {
       problems.push(`${preset}: dist/presets/${preset}.js contains length-${otherDegree} arrays, which belong to ${otherPreset}.`)
     }
   }

--- a/examples/CRISP/scripts/check-presets.mjs
+++ b/examples/CRISP/scripts/check-presets.mjs
@@ -5,12 +5,10 @@
 // without even the implied warranty of MERCHANTABILITY
 // or FITNESS FOR A PARTICULAR PURPOSE.
 
-// Refuse to publish a channel whose artifacts do not match the preset that channel stands for.
+// Refuse to publish a channel whose artifacts do not match the presets that channel stands for.
 //
-// The release channels are split by BFV preset: `testing` carries insecure-512 and `latest` carries
-// secure-8192. A tarball therefore has to carry exactly one preset — the missing one must be
-// missing, so importing it fails to resolve, and the wrong one must be absent, so a prod consumer
-// cannot reach insecure parameters at all.
+// The testing channel carries only insecure-512 so testnet installs stay small. The production
+// channel carries both presets so one client can select the preset from the E3's on-chain param set.
 //
 // The SDK and the contracts package are checked together because they are a matched pair. The SDK
 // inlines the compiled circuit and the contracts package ships the verifier generated from that
@@ -25,8 +23,13 @@ const CRISP = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const SDK = join(CRISP, 'packages', 'crisp-sdk')
 const CONTRACTS = join(CRISP, 'packages', 'crisp-contracts')
 
-/** Which preset each release channel stands for. */
-const CHANNEL_PRESET = { testing: 'insecure-512', latest: 'secure-8192' }
+/** Which presets each release channel carries. */
+const CHANNEL_PRESETS = {
+  testing: ['insecure-512'],
+  latest: ['insecure-512', 'secure-8192'],
+}
+
+const ALL_PRESETS = [...new Set(Object.values(CHANNEL_PRESETS).flat())]
 
 /** Generated per census mode. Not preset-specific — see packages/crisp-contracts/scripts/verifiers.ts. */
 const VERIFIERS = ['CRISPVerifier.sol', 'CRISPOnchainVerifier.sol']
@@ -40,41 +43,47 @@ const MIN_BYTES = 100 * 1024
 // npm gives `prepublishOnly` no way to see `--tag`, so the channel comes through the environment
 // when the publish scripts set it, and through argv when run by hand.
 const channel = process.argv[2] ?? process.env.CRISP_CHANNEL
-if (!Object.hasOwn(CHANNEL_PRESET, channel)) {
+if (!channel || !Object.hasOwn(CHANNEL_PRESETS, channel)) {
   console.error(
     channel === undefined
-      ? `Set CRISP_CHANNEL or pass a channel: check-presets.mjs <${Object.keys(CHANNEL_PRESET).join('|')}>`
-      : `Unknown channel "${channel}"; expected one of ${Object.keys(CHANNEL_PRESET).join(', ')}.`,
+      ? `Set CRISP_CHANNEL or pass a channel: check-presets.mjs <${Object.keys(CHANNEL_PRESETS).join('|')}>`
+      : `Unknown channel "${channel}"; expected one of ${Object.keys(CHANNEL_PRESETS).join(', ')}.`,
   )
   process.exit(1)
 }
 
-const wanted = CHANNEL_PRESET[channel]
-const others = Object.values(CHANNEL_PRESET).filter((preset) => preset !== wanted)
+const wanted = CHANNEL_PRESETS[channel]
+const others = ALL_PRESETS.filter((preset) => !wanted.includes(preset))
 const problems = []
 
 // --- the SDK bundle ---
-const built = join(SDK, 'dist', 'presets', `${wanted}.js`)
-if (!existsSync(built)) {
-  problems.push(`${wanted}: dist/presets/${wanted}.js is missing — run \`pnpm build:presets\`, then \`CRISP_PRESET=${wanted} pnpm build\`.`)
-} else if (statSync(built).size < MIN_BYTES) {
-  problems.push(`${wanted}: dist/presets/${wanted}.js is only ${statSync(built).size} bytes; the circuits did not inline.`)
-}
-
-for (const other of others) {
-  if (existsSync(join(SDK, 'dist', 'presets', `${other}.js`))) {
-    problems.push(`${other}: dist/presets/${other}.js must not ship on "${channel}" — rebuild with CRISP_PRESET=${wanted}.`)
+const built = new Map()
+for (const preset of wanted) {
+  const path = join(SDK, 'dist', 'presets', `${preset}.js`)
+  built.set(preset, path)
+  if (!existsSync(path)) {
+    problems.push(`${preset}: dist/presets/${preset}.js is missing — run \`pnpm build:presets\`, then rebuild the SDK.`)
+  } else if (statSync(path).size < MIN_BYTES) {
+    problems.push(`${preset}: dist/presets/${preset}.js is only ${statSync(path).size} bytes; the circuits did not inline.`)
   }
 }
 
 // The exports map is what consumers actually resolve, so check it points at a real file.
 const pkg = JSON.parse(readFileSync(join(SDK, 'package.json'), 'utf8'))
-const entry = pkg.exports?.[`./${wanted}`]
-if (!entry) {
-  problems.push(`${wanted}: package.json exports has no "./${wanted}" subpath.`)
-} else {
-  for (const target of new Set(Object.values(entry))) {
-    if (!existsSync(join(SDK, target))) problems.push(`${wanted}: exports points at ${target}, which does not exist.`)
+for (const preset of wanted) {
+  const entry = pkg.exports?.[`./${preset}`]
+  if (!entry) {
+    problems.push(`${preset}: package.json exports has no "./${preset}" subpath.`)
+  } else {
+    for (const target of new Set(Object.values(entry))) {
+      if (!existsSync(join(SDK, target))) problems.push(`${preset}: exports points at ${target}, which does not exist.`)
+    }
+  }
+}
+
+for (const other of others) {
+  if (existsSync(join(SDK, 'dist', 'presets', `${other}.js`))) {
+    problems.push(`${other}: dist/presets/${other}.js must not ship on "${channel}".`)
   }
 }
 
@@ -83,20 +92,25 @@ if (!entry) {
 // The filename says which preset a bundle is; this checks the contents agree. A bundle built from
 // the wrong staged artifacts would ship under the right name and fail only at on-chain
 // verification, which is the whole failure mode these channels exist to prevent.
-if (existsSync(built)) {
-  const source = readFileSync(built, 'utf8')
-  const degree = EXPECTED_DEGREE[wanted]
-  const other = Object.entries(EXPECTED_DEGREE).find(([preset]) => preset !== wanted)
+for (const preset of wanted) {
+  const path = built.get(preset)
+  if (!existsSync(path)) continue
+
+  const source = readFileSync(path, 'utf8')
+  const degree = EXPECTED_DEGREE[preset]
+  const unexpected = Object.entries(EXPECTED_DEGREE).filter(([candidate]) => candidate !== preset)
 
   // The bundler may emit the inlined JSON as a JS object literal, so the key can be quoted or bare
   // and the space is optional. Match all of those rather than one spelling.
   const hasDegree = (value) => new RegExp(`["']?length["']?\\s*:\\s*${value}\\b`).test(source)
 
   if (!hasDegree(degree)) {
-    problems.push(`${wanted}: dist/presets/${wanted}.js contains no length-${degree} arrays; the inlined circuits are not ${wanted}.`)
+    problems.push(`${preset}: dist/presets/${preset}.js contains no length-${degree} arrays; the inlined circuits are not ${preset}.`)
   }
-  if (other && hasDegree(other[1])) {
-    problems.push(`${wanted}: dist/presets/${wanted}.js contains length-${other[1]} arrays, which belong to ${other[0]}.`)
+  for (const [otherPreset, otherDegree] of unexpected) {
+    if (hasDegree(otherDegree)) {
+      problems.push(`${preset}: dist/presets/${preset}.js contains length-${otherDegree} arrays, which belong to ${otherPreset}.`)
+    }
   }
 }
 
@@ -111,10 +125,10 @@ for (const verifier of VERIFIERS) {
 }
 
 if (problems.length > 0) {
-  console.error(`✗ Not publishable on "${channel}" (expects ${wanted}):`)
+  console.error(`✗ Not publishable on "${channel}" (expects ${wanted.join(', ')}):`)
   for (const problem of problems) console.error(`  - ${problem}`)
   process.exit(1)
 }
 
-const size = (statSync(built).size / 1048576).toFixed(1)
-console.log(`✓ "${channel}" carries ${wanted} only (dist/presets/${wanted}.js ${size}MB, verifiers present).`)
+const sizes = wanted.map((preset) => `${preset} ${(statSync(built.get(preset)).size / 1048576).toFixed(1)}MB`).join(', ')
+console.log(`✓ "${channel}" carries ${wanted.join(', ')} (${sizes}; verifiers present).`)

--- a/examples/CRISP/scripts/check-staged-preset.mjs
+++ b/examples/CRISP/scripts/check-staged-preset.mjs
@@ -24,7 +24,7 @@ import { circuitSourcesDigest } from './circuit-sources.mjs'
 const CRISP = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const PRESETS = ['insecure-512', 'secure-8192']
 
-const RESTAGE = 'Run `pnpm build:presets` from examples/CRISP; it compiles both presets and archives them.'
+const RESTAGE = 'Run `pnpm build:presets` for one preset, or `pnpm build:presets:all` for both presets, from examples/CRISP.'
 
 const fail = (...lines) => {
   for (const line of lines) console.error(line)

--- a/examples/CRISP/scripts/publish.ts
+++ b/examples/CRISP/scripts/publish.ts
@@ -24,32 +24,29 @@ const PACKAGE_DIRS = ['packages/crisp-sdk', 'packages/crisp-contracts', 'package
 /**
  * Release channels, split by BFV preset.
  *
- * The SDK inlines the compiled circuit and the contracts package ships the verifier generated from
- * that same circuit's verification key, so a channel that mixes presets produces a round which
- * rejects every ballot — and it fails at on-chain verification, not anywhere a test would catch it.
- * Each channel therefore carries exactly one preset, and the preset decides the build.
+ * The SDK inlines compiled circuit artifacts. Testing releases carry only the insecure preset so
+ * they stay small; production releases carry both presets so one client can select the preset from
+ * the E3's on-chain param set.
  *
  * Testing versions carry a prerelease identifier so npm keeps them out of ordinary ranges: a
  * consumer on `^0.18.0` can never drift onto a testing build through an update.
  *
- * `tracksClient` says whether a channel moves the demo client onto the version it publishes. The
- * deployed client runs against a testnet whose verifiers were deployed from insecure-512, so only
- * the testing channel moves it. A prod publish that bumped the client would put secure-8192
- * circuits in front of an insecure-512 deployment, and every ballot would fail on chain. Move the
- * client to a prod version deliberately, in the same change as the redeploy it needs.
+ * `tracksClient` says whether a channel moves the client onto the version it publishes. The
+ * production channel moves it because the published package contains both presets. Testing releases
+ * leave it alone.
  *
  * `bumpsRepo` says whether a channel leaves its version behind in the working tree. It follows from
  * `tracksClient` and cannot be chosen independently: the client pins an exact version, and pnpm
- * links a workspace package only while its version still satisfies that pin. Leaving the workspace
- * on a prod version therefore detaches the client from `packages/crisp-sdk` and silently resolves
- * it from the registry instead — which changes what the whole client dependency tree resolves to,
- * and makes Vite pre-bundle the SDK as an ordinary dependency, breaking its worker entry point. So
- * a prod publish restores the versions it bumped and leaves the tree exactly as it found it. The
- * release is recorded on npm, which is the only place a published version needs to exist.
+ * links a workspace package only while its version still satisfies that pin. A production publish
+ * leaves the workspace and client on the same exact version, so local development uses the
+ * workspace and standalone deploys use the matching npm package.
  */
+const PRESETS = ['insecure-512', 'secure-8192'] as const
+type Preset = (typeof PRESETS)[number]
+
 const CHANNELS = {
-  testing: { tag: 'testing', preset: 'insecure-512', prerelease: true, tracksClient: true, bumpsRepo: true },
-  prod: { tag: 'latest', preset: 'secure-8192', prerelease: false, tracksClient: false, bumpsRepo: false },
+  testing: { tag: 'testing', presets: ['insecure-512'] as readonly Preset[], prerelease: true, tracksClient: false, bumpsRepo: false },
+  prod: { tag: 'latest', presets: PRESETS, prerelease: false, tracksClient: true, bumpsRepo: true },
 } as const
 
 type Channel = keyof typeof CHANNELS
@@ -120,37 +117,16 @@ class CRISPPublisher {
     console.log(`   Package versions are back at ${this.oldVersion ?? 'their previous value'}; npm keeps what was published.`)
   }
 
-  /**
-   * The demo client stays on the testing channel, always.
-   *
-   * It is deployed against a testnet whose verifiers were deployed from insecure-512 circuits, so a
-   * secure-8192 SDK in front of it would make every ballot fail on chain. Only the testing channel
-   * moves the pin, and this refuses to publish at all when something else has moved it — a client
-   * on a plain release version is already wrong, and a publish would carry that wrong state
-   * forward.
-   *
-   * The pin is an exact version rather than the `testing` dist-tag: the client deploys from its own
-   * lock file (client/.npmrc, client/vercel.json), so the version has to be fixed at the point the
-   * lock file is written.
-   */
-  private assertClientOnTestingChannel(): void {
+  /** Report the client pin that the selected channel may update. */
+  private reportClientPin(): void {
     const pin = this.clientPin()
 
     if (pin === null) {
-      console.warn('   ⚠️  Could not read the client pin on @crisp-e3/sdk; skipping the channel check')
+      console.warn('   ⚠️  Could not read the client pin on @crisp-e3/sdk')
       return
     }
 
-    // Testing versions are the prereleases. See validateVersion().
-    if (!pin.includes('-')) {
-      throw new Error(
-        `client/package.json pins @crisp-e3/sdk ${pin}, which is not a testing version. The client ` +
-          `runs against an insecure-512 deployment and must stay on the testing channel. Restore a ` +
-          `prerelease pin (for example ${pin}-insecure.0) before publishing.`,
-      )
-    }
-
-    console.log(`📌 Client pin: ${pin} (testing channel)`)
+    console.log(`📌 Client pin: ${pin}`)
   }
 
   /** The version the demo client currently pins, for reporting. Null when it cannot be read. */
@@ -181,8 +157,7 @@ class CRISPPublisher {
       this.oldVersion = this.getCurrentVersion()
       console.log(`📌 Current version: ${this.oldVersion || 'unknown'}`)
 
-      // The client tracks the testing channel on every publish, whichever channel this one is.
-      this.assertClientOnTestingChannel()
+      this.reportClientPin()
 
       // Check for uncommitted changes
       if (!this.options.skipGit && !this.options.dryRun) {
@@ -198,7 +173,7 @@ class CRISPPublisher {
           ['Update package versions in:', ...packages],
           ...(this.tracksClient ? [['Update @crisp-e3/sdk dependency in client/package.json']] : []),
           ['Update pnpm-lock.yaml'],
-          [`Build packages against ${channel.preset}`],
+          [`Build packages against ${channel.presets.join(', ')}`],
           [`Publish to npm under the "${this.options.tag || channel.tag}" tag:`, ...packages],
           ...(this.tracksClient ? [['Update the standalone client/pnpm-lock.yaml']] : []),
           ...(channel.bumpsRepo
@@ -218,7 +193,7 @@ class CRISPPublisher {
           console.log(`\n   The client stays on ${this.clientPin() ?? 'its current pin'}; channel "${this.channel}" does not move it.`)
         }
         if (!channel.bumpsRepo) {
-          console.log(`   Nothing is committed: the workspace must keep satisfying that pin, or the client stops linking to it.`)
+          console.log('   Nothing is committed: this channel restores the package version bump after publishing.')
         }
 
         console.log('\n✅ Dry run complete. Run without --dry-run to perform these actions.')
@@ -232,7 +207,7 @@ class CRISPPublisher {
       this.bumpNpmPackages()
 
       try {
-        // Update client dependency. Only the testing channel does this — see tracksClient().
+        // Update client dependency when the selected channel owns the deployable client pin.
         if (this.tracksClient) {
           this.updateClientDependency()
         }
@@ -273,7 +248,7 @@ class CRISPPublisher {
       console.log(`   Previous version: ${this.oldVersion || 'unknown'}`)
       console.log(`   New version: ${this.newVersion}`)
       console.log(
-        `   Channel: ${this.channel} (${CHANNELS[this.channel].preset}, npm tag ${this.options.tag || CHANNELS[this.channel].tag})`,
+        `   Channel: ${this.channel} (${CHANNELS[this.channel].presets.join(', ')}, npm tag ${this.options.tag || CHANNELS[this.channel].tag})`,
       )
       console.log(`   Packages updated: ✓`)
       console.log(`   Client dependency: ${this.tracksClient ? '✓ updated' : `↷ left on ${this.clientPin() ?? 'its own pin'}`}`)
@@ -325,14 +300,20 @@ class CRISPPublisher {
         const packageJsonPath = join(pkgPath, 'package.json')
         const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
 
-        // The SDK bundles the preset-bound circuits, so it builds per channel. Everything else is
+        // The SDK bundles preset-bound circuits, so it builds per channel. Everything else is
         // preset-free and builds once.
         const buildScript = pkg.path === 'packages/crisp-sdk' ? `build:${this.channel}` : 'build'
         if (packageJson.scripts && packageJson.scripts[buildScript]) {
+          const buildEnv = { ...process.env }
+          if (CHANNELS[this.channel].presets.length === 1) {
+            buildEnv.CRISP_PRESET = CHANNELS[this.channel].presets[0]
+          } else {
+            delete buildEnv.CRISP_PRESET
+          }
           execSync(`pnpm ${buildScript}`, {
             cwd: pkgPath,
             stdio: 'inherit',
-            env: { ...process.env, CRISP_PRESET: CHANNELS[this.channel].preset },
+            env: buildEnv,
           })
           console.log(`   ✓ ${pkg.name} built successfully`)
         } else {
@@ -361,7 +342,7 @@ class CRISPPublisher {
     ]
 
     const tag = this.options.tag || CHANNELS[this.channel].tag
-    console.log(`   Channel: ${this.channel} (${CHANNELS[this.channel].preset}), npm tag: ${tag}`)
+    console.log(`   Channel: ${this.channel} (${CHANNELS[this.channel].presets.join(', ')}), npm tag: ${tag}`)
 
     for (const pkg of packagesToPublish) {
       try {
@@ -373,8 +354,9 @@ class CRISPPublisher {
           cwd: pkgPath,
           stdio: 'inherit',
           // `prepublishOnly` runs check-presets.mjs, which refuses to publish a channel whose
-          // artifacts carry the wrong preset. npm gives it no way to see --tag, so it reads this.
-          env: { ...process.env, CRISP_CHANNEL: tag },
+          // artifacts carry the wrong preset set. npm gives it no way to see our channel, so it
+          // reads this. A custom npm dist-tag must not change the preset policy.
+          env: { ...process.env, CRISP_CHANNEL: CHANNELS[this.channel].tag },
         })
 
         console.log(`   ✓ ${pkg.name}@${this.newVersion} published successfully`)
@@ -434,9 +416,20 @@ class CRISPPublisher {
         console.warn('   ⚠️  Prettier failed, continuing anyway')
       }
 
-      // Add all changes
+      // Add the exact files this script owns, including the root workspace lockfile.
       console.log('   Adding changes...')
-      execSync('git add .', { cwd: this.crispDir })
+      execSync(
+        [
+          'git add',
+          'examples/CRISP/packages/crisp-sdk/package.json',
+          'examples/CRISP/packages/crisp-contracts/package.json',
+          'examples/CRISP/packages/crisp-zk-inputs/package.json',
+          'examples/CRISP/client/package.json',
+          'examples/CRISP/client/pnpm-lock.yaml',
+          'pnpm-lock.yaml',
+        ].join(' '),
+        { cwd: rootDir },
+      )
 
       // Create commit message
       const commitMessage = `chore(crisp): publish version ${this.newVersion}
@@ -704,7 +697,7 @@ Arguments:
   version             The new version (e.g., 1.0.0, 1.0.0-beta.1)
 
 Options:
-  --channel <name>    Release channel: 'testing' (insecure-512) or 'prod' (secure-8192). Required.
+  --channel <name>    Release channel: 'testing' (insecure-512) or 'prod' (both presets). Required.
   --tag <name>        npm dist-tag override (default: the channel's tag)
   --skip-git          Skip all git operations (no commit)
   --dry-run           Show what would be done without making changes
@@ -712,18 +705,16 @@ Options:
 
 Channels:
   testing   npm tag 'testing', insecure-512 circuits, prerelease versions only
-  prod      npm tag 'latest',  secure-8192 circuits, plain release versions only
+  prod      npm tag 'latest',  insecure-512 and secure-8192 circuits, plain release versions only
 
-  Each channel carries exactly one preset. The SDK inlines the compiled circuit and the contracts
-  package ships the verifier generated from that circuit's verification key, so mixing them
-  produces a round that rejects every ballot, and it fails on chain rather than in any test.
+  Testing carries one preset to stay small. Production carries both presets so the client can select
+  the required circuit bundle from the E3's on-chain param set.
 
   Testing versions must carry a prerelease identifier. npm keeps prereleases out of ordinary
   ranges, so a consumer on '^0.18.0' cannot drift onto a testing build through an update.
 
-  Only 'testing' moves the demo client. The deployed client runs against a testnet whose verifiers
-  came from insecure-512, so a prod publish leaves client/package.json and client/pnpm-lock.yaml
-  alone. Move the client to a prod version in the same change as the redeploy it needs.
+  Only 'prod' moves the deployable client. A testing publish leaves client/package.json and
+  client/pnpm-lock.yaml alone.
 
 Prerequisite:
   Both channels build from the artifacts that 'pnpm build:presets' archives under circuits/dist/,
@@ -735,7 +726,7 @@ Examples:
   tsx scripts/publish.ts --channel testing 0.18.0-insecure.0
 
   # Publish to production
-  tsx scripts/publish.ts --channel prod 0.18.0
+  tsx scripts/publish.ts --channel prod 0.20.0
 
   # Test without publishing
   tsx scripts/publish.ts --channel testing --dry-run 0.18.0-insecure.0
@@ -746,12 +737,12 @@ Examples:
 The script will:
   1. Check for uncommitted changes
   2. Update versions in @crisp-e3/sdk, @crisp-e3/contracts, @crisp-e3/zk-inputs
-  2b. Build the SDK against the channel's preset
-  3. Update @crisp-e3/sdk dependency in client/package.json   (testing only)
+  2b. Build the SDK against the channel's preset set
+  3. Update @crisp-e3/sdk dependency in client/package.json   (prod only)
   4. Update pnpm-lock.yaml
   5. Build packages
   6. Publish to npm in dependency order (zk-inputs, then sdk, then contracts)
-  7. Update the standalone client/pnpm-lock.yaml               (testing only)
+  7. Update the standalone client/pnpm-lock.yaml               (prod only)
   8. Commit changes (no tags)
 
 Note: Make sure you're logged in to npm (npm login) before publishing.

--- a/examples/CRISP/scripts/publish.ts
+++ b/examples/CRISP/scripts/publish.ts
@@ -717,9 +717,9 @@ Channels:
   client/pnpm-lock.yaml alone.
 
 Prerequisite:
-  Both channels build from the artifacts that 'pnpm build:presets' archives under circuits/dist/,
-  which git does not track. Run it first when the circuits changed; the SDK build refuses stale or
-  missing artifacts (pnpm -C packages/crisp-sdk check:staged <preset>).
+  The SDK build stages the circuit artifacts it needs under circuits/dist/, which git does not
+  track. The testing channel stages only insecure-512. The production channel stages both presets.
+  The build refuses stale or missing artifacts (pnpm -C packages/crisp-sdk check:staged <preset>).
 
 Examples:
   # Publish to the testing channel (testnets, demos)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
   examples/CRISP/client:
     dependencies:
       '@crisp-e3/sdk':
-        specifier: 0.18.0-insecure.0
-        version: 0.18.0-insecure.0(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.4.3)
+        specifier: 0.20.0
+        version: link:../packages/crisp-sdk
       '@emotion/babel-plugin':
         specifier: ^11.11.0
         version: 11.13.5
@@ -1725,12 +1725,6 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
-
-  '@crisp-e3/sdk@0.18.0-insecure.0':
-    resolution: {integrity: sha512-1qwFF8sR1VDDoSH178gr+DzluMThGhdCNpx9SsMJLC+gpPlU8A7qKThNv1P7hxaMB12q15so6KJumhL7euf7Gg==}
-
-  '@crisp-e3/zk-inputs@0.18.0-insecure.0':
-    resolution: {integrity: sha512-vgIb8cixmxeLTYEfvmKlzGzMDQg1/Y1xc9wIcSrlDBZRxEdHz3bpnBV59GPVCG4Fx5obXHKDvILhyIdT2n8Nqw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -12106,22 +12100,6 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
-
-  '@crisp-e3/sdk@0.18.0-insecure.0(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.4.3)':
-    dependencies:
-      '@aztec/bb.js': 5.1.0
-      '@crisp-e3/zk-inputs': 0.18.0-insecure.0
-      '@noir-lang/noir_js': 1.0.0-beta.26
-      '@zk-kit/lean-imt': 2.2.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      poseidon-lite: 0.3.0
-      viem: 2.38.6(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@5.0.10)(zod@4.4.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - typescript
-      - utf-8-validate
-      - zod
-
-  '@crisp-e3/zk-inputs@0.18.0-insecure.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
## Summary
- package production CRISP SDK builds with both insecure-512 and secure-8192 preset entry points
- make the CRISP client load the circuit bundle from the E3 on-chain paramSet instead of hardcoding insecure-512
- update the CRISP publish flow so prod publishes both presets and moves the deployable client, while testing remains insecure-only
- bump the CRISP package/client pins to 0.20.0 so workspace CI links the local dual-preset SDK

## Notes
- The root pnpm lock links the client to the workspace SDK for CI before 0.20.0 exists on npm.
- The standalone client lockfile is intentionally left for the production publish step; the publish script updates it after npm serves @crisp-e3/sdk@0.20.0.
- Client build needs a larger Node heap because the production SDK now includes the secure circuit chunk.

## Verification
- pnpm -C examples/CRISP/packages/crisp-sdk build:prod
- node examples/CRISP/scripts/check-presets.mjs latest
- pnpm -C examples/CRISP/client exec tsc --noEmit
- pnpm -C examples/CRISP/client build
- pnpm -C examples/CRISP lint
- pnpm -C examples/CRISP publish:packages --channel prod --dry-run 0.20.0
- npm pack --dry-run --json (crisp-sdk: 14.5 MB packed, 35.7 MB unpacked)
- git pre-push hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRISP production releases now support both `insecure-512` and `secure-8192` presets, with automatic selection based on configuration.
  * Presets can be loaded on demand through separate package entry points.
  * Circuit loading includes caching, validation, and retry handling.

* **Documentation**
  * Updated release, deployment, and preset-selection guidance.

* **Improvements**
  * Testing releases remain isolated from production client updates.
  * Production builds validate all supported preset bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->