### PR TITLE
docs: refine documentation navigation

### DIFF
--- a/docs/pages/_meta.json
+++ b/docs/pages/_meta.json
@@ -56,10 +56,10 @@
     "title": "Project Template"
   },
   "sdk": {
-    "title": "Interfold SDK"
+    "title": "SDK"
   },
   "setting-up-server": {
-    "title": "Setting Up the Server"
+    "title": "Server Setup"
   },
   "noir-circuits": {
     "title": "Noir Circuits"
@@ -73,19 +73,27 @@
     "title": "Getting Started"
   },
   "write-secure-program": {
-    "title": "Writing the Secure Process"
+    "title": "Secure Process"
   },
   "write-e3-contract": {
-    "title": "Writing the E3 Program Contract"
+    "title": "E3 Program Contract"
   },
   "compute-provider": {
     "title": "Compute Provider Setup"
   },
   "verifying-the-compute-provider": {
-    "title": "Verifying the Compute Provider"
+    "title": "Verify Compute Provider"
   },
   "putting-it-together": {
     "title": "Putting It All Together"
+  },
+
+  "-- Tutorials": {
+    "type": "separator",
+    "title": "Tutorials"
+  },
+  "tutorials": {
+    "title": "Tutorials"
   },
 
   "-- Participate": {
@@ -93,16 +101,16 @@
     "title": "Participate"
   },
   "governance": {
-    "title": "Interfold Governance"
+    "title": "Governance"
   },
   "constitution": {
-    "title": "The Interfold Constitution"
+    "title": "DAO Constitution"
   },
   "tokenomics": {
     "title": "Tokenomics"
   },
   "faq": {
-    "title": "Frequently Asked Questions"
+    "title": "FOLD FAQ"
   },
   "requestor-guide": {
     "title": "Requestor Guide"


### PR DESCRIPTION
## What

Refines the documentation sidebar for clearer navigation and restores the existing Tutorials tree to its intended position.

This also shortens several sidebar labels for readability while preserving all existing routes, file locations, page content, and ordered documentation flows.

## Checklist

- [x] **Verified at the smallest covering scope** — navigation-only docs change; reviewed the root and tutorials `_meta.json` structure and confirmed existing page keys/routes are preserved.
- [x] **Harness docs** — not applicable; no contracts, circuits, actor routing, CLI behavior, or formulas changed.
- [x] **Invariants** — not applicable to this docs-navigation-only change; no protocol invariant behavior changed.
- [x] **Known bugs table** — not applicable; no protocol concern is fixed or introduced.
- [x] **Breaking?** — no.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation navigation titles for improved clarity.
  * Added a dedicated Tutorials section.
  * Renamed several Build and Participate entries for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->