### PR TITLE
chore(ci): move trusted workflows to RunsOn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,16 @@ env:
 permissions:
   contents: read
 
+# The migrated jobs use RunsOn only for protected branch events.
+# Pull requests keep their previous runner targets, including enclave-ci where configured.
+# Each RunsOn label embeds run id, attempt, and job ID so jobs never share runners.
 jobs:
   detect_changes:
     timeout-minutes: 5
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'detect_changes') || 'ubuntu-latest' }}
     outputs:
       rust_unit_tests: ${{ steps.jobs.outputs.rust_unit_tests }}
       rust_integration_tests: ${{ steps.jobs.outputs.rust_integration_tests }}
@@ -172,7 +178,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.rust_unit_tests == 'true'
     timeout-minutes: 20
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'rust_unit_tests') || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: write
@@ -281,7 +290,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.zk_prover_integration == 'true'
     timeout-minutes: 30
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'zk_prover_integration') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -347,7 +359,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.docker_support == 'true'
     timeout-minutes: 30
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16/spot=false', github.run_id,
+      github.run_attempt, 'build_e3_support_risc0') || 'ubuntu-latest' }}
     permissions:
       contents: read
       packages: write
@@ -391,7 +406,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.docker_ciphernode == 'true'
     timeout-minutes: 60
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16/spot=false', github.run_id,
+      github.run_attempt, 'build_ciphernode_image') || 'ubuntu-latest' }}
     permissions:
       contents: read
       packages: write
@@ -437,7 +455,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.contracts == 'true'
     timeout-minutes: 15
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'test_contracts') || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: write
@@ -495,7 +516,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.net == 'true'
     timeout-minutes: 15
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'test_net') || 'ubuntu-latest' }}
     steps:
       - name: 'Check out the repo'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6
@@ -511,7 +535,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.integration_prebuild == 'true'
     timeout-minutes: 30
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'integration_prebuild') || 'ubuntu-latest' }}
     steps:
       - name: 'Check out the repo'
         uses: 'actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10' # v6
@@ -707,10 +734,13 @@ jobs:
   crisp_unit:
     needs: [detect_changes, build_crisp_sdk]
     if: needs.detect_changes.outputs.crisp == 'true'
-    # Per leg, because they are not remotely the same size. Anything that generates a ballot proves
-    # five Noir circuits, which a two-vCPU runner takes minutes to do; everything else is seconds.
+    # Use a timeout for each leg because the workloads differ. Tests that generate a ballot prove
+    # five Noir circuits and can take several minutes. Other tests complete in seconds.
     timeout-minutes: ${{ matrix.timeout }}
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}-{3}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'crisp_unit', matrix['test-suite']) || 'ubuntu-latest' }}
     strategy:
       matrix:
         include:
@@ -977,7 +1007,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.build_circuits == 'true'
     timeout-minutes: 30
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'build_circuits') || 'ubuntu-latest' }}
     permissions:
       contents: read
       actions: write
@@ -1120,7 +1153,10 @@ jobs:
     needs: [detect_changes, build_circuits]
     if: needs.detect_changes.outputs.zk == 'true'
     timeout-minutes: 30
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'zk_prover_e2e') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -1201,7 +1237,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.build_e3_support_dev == 'true'
     timeout-minutes: 20
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'build_e3_support_dev') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -1237,7 +1276,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.build_sdk == 'true'
     timeout-minutes: 30
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'build_sdk') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -1310,7 +1352,10 @@ jobs:
     needs: [detect_changes]
     if: needs.detect_changes.outputs.crisp == 'true'
     timeout-minutes: 20
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'build_crisp_sdk') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
@@ -1481,7 +1526,10 @@ jobs:
     needs: [detect_changes, build_interfold_cli, build_e3_support_dev]
     if: needs.detect_changes.outputs.init == 'true'
     timeout-minutes: 10
-    runs-on: 'ubuntu-latest'
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'test_interfold_init') || 'ubuntu-latest' }}
     steps:
       - name: Install pnpm
         uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4

--- a/.github/workflows/cleanup-merged.yml
+++ b/.github/workflows/cleanup-merged.yml
@@ -19,9 +19,12 @@ on:
 permissions:
   contents: write
 
+# Each RunsOn label embeds run id, attempt, and job ID so jobs never share runners.
 jobs:
   tidy:
-    runs-on: ubuntu-latest
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') &&
+      format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt, 'tidy') || 'ubuntu-latest' }}
     steps:
       - name: Prune merged branches
         uses: actions/github-script@v7

--- a/.github/workflows/crisp-docker.yml
+++ b/.github/workflows/crisp-docker.yml
@@ -23,10 +23,15 @@ permissions:
   contents: read
   packages: write
 
+# Pull requests stay on GitHub-hosted runners. Only protected branch events use RunsOn.
+# Each RunsOn label embeds run id, attempt, and job ID so jobs never share runners.
 jobs:
   build:
     name: Build & Push Image
-    runs-on: ubuntu-latest
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16/spot=false', github.run_id,
+      github.run_attempt, 'build') || 'ubuntu-latest' }}
     outputs:
       image_tag: ${{ steps.version.outputs.version }}
     steps:

--- a/.github/workflows/license-check-comment.yml
+++ b/.github/workflows/license-check-comment.yml
@@ -1,0 +1,70 @@
+name: License Header Comment
+
+on:
+  # zizmor: ignore[dangerous-triggers] This job uses only API metadata and never runs triggering-workflow code.
+  workflow_run:
+    workflows: [License Header Check]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  comment-on-pr:
+    name: Comment on missing license headers
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    # Read the triggering job result and post the matching pull request notice.
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Comment on PR if headers are missing
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const workflowRun = context.payload.workflow_run
+            const pullRequest = workflowRun.pull_requests[0]
+
+            if (!pullRequest) {
+              core.notice('No pull request is associated with this workflow run')
+              return
+            }
+
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: workflowRun.id,
+              per_page: 100,
+            })
+            const licenseJob = jobs.find((job) => job.name === 'Check SPDX License Headers')
+            const failureStep = licenseJob?.steps?.find(
+              (step) => step.name === 'Fail job if headers are missing (PR only)',
+            )
+
+            if (failureStep?.conclusion !== 'failure') {
+              core.notice('The license header failure step did not fail; no comment is needed')
+              return
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: pullRequest.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ **License Header Check Failed**
+
+              Some files are missing the required SPDX license header. Please add the following header to the beginning of all \`.js\`, \`.jsx\`, \`.nr\`, \`.rs\`, \`.sol\`, \`.ts\`, and \`.tsx\` files:
+
+              \`\`\`
+              // SPDX-License-Identifier: LGPL-3.0-only
+              //
+              // This file is provided WITHOUT ANY WARRANTY;
+              // without even the implied warranty of MERCHANTABILITY
+              // or FITNESS FOR A PARTICULAR PURPOSE.
+              \`\`\`
+
+              You can run \`./scripts/check-license-headers.sh --fix\` locally to automatically add missing headers, then commit the changes.
+
+              Or run \`./scripts/check-license-headers.sh\` to see which files need headers.`,
+            })

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -6,9 +6,14 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Pull requests stay on GitHub-hosted runners. Only protected branch events use RunsOn.
+# Each RunsOn label embeds run id, attempt, and job ID so jobs never share runners.
 jobs:
   license-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      ${{ github.repository == 'theinterfold/interfold' && github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/dev') && format('runs-on={0}-{1}-{2}/runner=4cpu-linux-x64/ram=16', github.run_id, github.run_attempt,
+      'license-check') || 'ubuntu-latest' }}
     name: Check SPDX License Headers
     outputs:
       needs-fix: ${{ steps.check-headers.outcome == 'failure' }}

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 # Pull requests stay on GitHub-hosted runners. Only protected branch events use RunsOn.
 # Each RunsOn label embeds run id, attempt, and job ID so jobs never share runners.
 jobs:
@@ -20,38 +23,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Check license headers
         id: check-headers
         run: ./scripts/check-license-headers.sh --check-only
         continue-on-error: true
-
-      - name: Comment on PR if headers are missing
-        if: steps.check-headers.outcome == 'failure' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `❌ **License Header Check Failed**
-              
-              Some files are missing the required SPDX license header. Please add the following header to the beginning of all \`.js\`, \`.jsx\`, \`.nr\`, \`.rs\`, \`.sol\`, \`.ts\`, and \`.tsx\` files:
-              
-              \`\`\`
-              // SPDX-License-Identifier: LGPL-3.0-only
-              //
-              // This file is provided WITHOUT ANY WARRANTY;
-              // without even the implied warranty of MERCHANTABILITY
-              // or FITNESS FOR A PARTICULAR PURPOSE.
-              \`\`\`
-              
-              You can run \`./scripts/check-license-headers.sh --fix\` locally to automatically add missing headers, then commit the changes.
-              
-              Or run \`./scripts/check-license-headers.sh\` to see which files need headers.`
-            })
 
       - name: Fail job if headers are missing (PR only)
         if: steps.check-headers.outcome == 'failure' && github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

- Apply the reviewed PR #1910 workflow changes to `main`.
- Route trusted `main` and `dev` jobs to RunsOn.
- Keep pull request and release jobs on GitHub-hosted runners.
- Use on-demand runners for jobs that publish external images.

## Validation

- `actionlint` passed after excluding existing ShellCheck and custom-runner warnings.
- Prettier passed for all four changed workflow files.
- The files match the reviewed result from PR #1910.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI, cleanup, Docker build, and license-check workflows to use isolated self-hosted runners for eligible main and development branch runs.
  * Pull requests and other non-targeted runs continue using standard hosted runners.
  * Added runner-specific resource settings for Docker builds and test-suite identification for CRISP jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->