### PR TITLE
fix: keep BondedVotes snapshots checkpointed

### DIFF
--- a/agent/INVARIANTS.md
+++ b/agent/INVARIANTS.md
@@ -64,29 +64,30 @@ design citation alone does not establish current runtime behavior.
   weight by bonding). Reading the denominator off the escrow instead would omit the bonded half and
   let participation exceed 100%. Summed voting power must never exceed total supply. —
   `BondedVotes.sol`; `flow-trace/02`
-- **Escrowed and bonded FOLD cannot overlap; vesting-locked and bonded do, and must be netted.**
-  Escrowing custodies the token in the escrow and bonding custodies it in the registry, so no token
-  can be in both. Both were transferred rather than burned, so both are still inside the token's
-  total supply — which is what makes the ratio sound in either configuration. Under an escrow votes
-  source `BondedVotes` adds a third source, `InterfoldToken.lockedBalanceAt`, because vesting-locked
-  FOLD sits in the holder's own wallet and the transfer hook will not let it reach the escrow. That
-  source **does** overlap the bond: a bond satisfies a lock (`transferableBalanceOf` nets the two),
-  so bonded FOLD is reported by `lockedBalanceAt` and by the bonded history while existing once.
-  `_lockedVotes` therefore subtracts the bond from the locked balance, saturating at zero, making
-  the pair worth `max(bonded, locked)` — then caps the result at the account's wallet balance,
-  because slashing takes the bond without taking the lock and would otherwise leave the account
-  voting with FOLD the slash recipient now holds. The lock schedule is read **only** when the votes
-  source is an escrow: when the token votes for itself, locked FOLD is wallet FOLD the token has
-  already counted. — `BondedVotes.sol`; `InterfoldToken.sol`; `flow-trace/02`
+- **Escrowed and bonded FOLD cannot overlap; live vesting-locked and bonded do, and must be
+  netted.** Escrowing custodies the token in the escrow and bonding custodies it in the registry, so
+  no token can be in both. Both were transferred rather than burned, so both are still inside the
+  token's total supply — which is what makes the ratio sound in either configuration. In `getVotes`,
+  under an escrow votes source, `BondedVotes` adds `InterfoldToken.lockedBalanceAt` because
+  vesting-locked FOLD sits in the holder's own wallet and the transfer hook will not let it reach
+  the escrow. That live source **does** overlap the bond: a bond satisfies a lock
+  (`transferableBalanceOf` nets the two), so bonded FOLD is reported by `lockedBalanceAt` and by the
+  bonded total while existing once. `_lockedVotes` therefore subtracts the bond from the locked
+  balance, saturating at zero, making the pair worth `max(bonded, locked)` — then caps the result at
+  the account's wallet balance, because slashing takes the bond without taking the lock and would
+  otherwise leave the account voting with FOLD the slash recipient now holds. The lock schedule is
+  read **only** for current votes and only when the votes source is an escrow: when the token votes
+  for itself, locked FOLD is wallet FOLD the token has already counted. — `BondedVotes.sol`;
+  `InterfoldToken.sol`; `flow-trace/02`
 - **The lock schedule is present-state, not history.** `lockedBalanceAt` walks an account's
   **current** locks and evaluates them against the timestamp given, so a lock created after a
-  governance snapshot appears in that snapshot's answer — unlike the bonded history, which is
-  checkpointed. Sound for vesting locks, which are minted or claimed rather than acquired at will;
-  it must not be treated as a general past balance. — `BondedVotes.sol`; `InterfoldToken.sol`
+  governance snapshot can appear in that snapshot's answer. `BondedVotes.getPastVotes` must not add
+  this present-state term. Historical voting power must come only from checkpointed sources until a
+  checkpointed lock source exists. — `BondedVotes.sol`; `InterfoldToken.sol`
 - **An escrow votes source requires a token with a lock schedule.** `_bindVotesSource` staticcalls
   `lockedBalanceAt` once at construction and reverts `LockedBalancesUnsupported` if it cannot
-  answer. Tolerating the failure at read time would return zero and disenfranchise exactly the
-  locked holders the third source exists to enfranchise. — `BondedVotes.sol`
+  answer. Tolerating the failure at live read time would return zero for exactly the locked holders
+  the current-vote path exists to enfranchise. — `BondedVotes.sol`
 - **Every summed source must share the token's clock.** `BondedCheckpoints` keys by
   `block.timestamp` to match `InterfoldToken`'s ERC-6372 `mode=timestamp`, and `BondedVotes`
   compares the history's clock **and** a non-token votes source's clock against the token's at

--- a/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
+++ b/agent/flow-trace/02_TOKENS_AND_ACTIVATION.md
@@ -477,8 +477,13 @@ BondedVotes.getPastVotes(account, t)              ← the NUMERATOR
 ├─ votesSource.getPastVotes(account, t)           ← either the token or an escrow adapter
 │    ├─ votesSource == token   → wallet-held FOLD (needs delegation)
 │    └─ votesSource == escrow  → only escrowed FOLD; idle wallet FOLD carries no weight
-├─ BondedCheckpoints.getPastBonded(account, t)    ← FOLD bonded as an operator
-└─ InterfoldToken.lockedBalanceAt(account, t)     ← vesting-locked FOLD, escrow source ONLY
+└─ BondedCheckpoints.getPastBonded(account, t)    ← FOLD bonded as an operator
+
+BondedVotes.getVotes(account)                     ← current voting power
+│
+├─ votesSource.getVotes(account)
+├─ BondedCheckpoints.bonded(account)
+└─ InterfoldToken.lockedBalanceAt(account, now)   ← live vesting-locked FOLD, escrow source ONLY
      minus the bonded total (saturating), because a bond satisfies a lock
 
 BondedVotes.getPastTotalSupply(t)                 ← the DENOMINATOR
@@ -499,38 +504,38 @@ token in the escrow and bonding custodies it in the registry.
 
 ### Vesting-locked FOLD
 
-Under an escrow votes source there is a third numerator: FOLD still encumbered by the token's own
-vesting locks. That FOLD sits in the holder's own wallet and `InterfoldToken._update` refuses to
-move it, so it can never be deposited into the escrow — without counting it, a locked holder would
-be barred from governance for the whole vesting schedule by a rule they cannot act on.
+Under an escrow votes source there is a third current numerator: FOLD still encumbered by the
+token's own vesting locks. That FOLD sits in the holder's own wallet and `InterfoldToken._update`
+refuses to move it, so it can never be deposited into the escrow. `BondedVotes.getVotes` counts the
+live lock term so current voting-power reads include that encumbered FOLD.
 
 Unlike the escrowed and bonded halves, this one **overlaps** the bond. A bond satisfies a lock:
 `transferableBalanceOf` lets a wallet move locked FOLD to the extent the bond already covers the
-obligation, so bonded FOLD is reported by both `lockedBalanceAt` and `getPastBonded` while existing
-exactly once. `_lockedVotes` subtracts the bonded total from the locked balance and saturates at
-zero, so the pair is worth `max(bonded, locked)` rather than their sum.
+obligation, so bonded FOLD is reported by both `lockedBalanceAt` and `bonded` while existing exactly
+once. `_lockedVotes` subtracts the bonded total from the locked balance and saturates at zero, so
+the pair is worth `max(bonded, locked)` rather than their sum.
 
 The netting rests on the token's transfer rule, `balance >= locked - bonded`, enforced on every
 transfer. **Slashing breaks that rule**: it takes the bond without touching the lock, so an operator
 that had already moved locked FOLD out on the strength of the bond is left owing more than it holds,
 and the unbonded remainder would vote with FOLD the slash recipient now holds and can count too.
-`_lockedVotes` therefore caps the term at the account's wallet balance. The cap reads the present
-balance even for a past timepoint — a bound, never a source: it can only lower the term towards what
-the account demonstrably holds, and only that account's own power.
+`_lockedVotes` therefore caps the term at the account's wallet balance. The cap is a bound, never a
+source: it can only lower the term towards what the account demonstrably holds, and only that
+account's own power.
 
 Two limits worth holding on to:
 
-- The lock schedule is read **only** when the votes source is an escrow. When the token votes for
-  itself, locked FOLD is wallet FOLD its own checkpoints already carry, and adding it would double
-  every locked holder's weight.
+- The lock schedule is read **only** by current `getVotes` when the votes source is an escrow. When
+  the token votes for itself, locked FOLD is wallet FOLD its own checkpoints already carry, and
+  adding it would double every locked holder's weight.
 - `lockedBalanceAt` is not a checkpointed history — it walks the account's **current** locks and
-  evaluates them against the timestamp given. A lock created after a snapshot shows up in that
-  snapshot's answer. That is acceptable for vesting locks, which are minted or claimed rather than
-  acquired at will, but it is not a general past balance.
+  evaluates them against the timestamp given. A lock created after a snapshot can show up in that
+  snapshot's answer. `BondedVotes.getPastVotes` therefore excludes the token lock schedule until a
+  checkpointed lock source exists.
 
 The constructor staticcalls `lockedBalanceAt` once when binding an escrow votes source and reverts
-`LockedBalancesUnsupported` if the token cannot answer, rather than catching the failure at read
-time and silently returning zero for every locked holder.
+`LockedBalancesUnsupported` if the token cannot answer, rather than catching the failure at live
+read time and silently returning zero for every locked holder.
 
 ### Checkpoint write sites
 

--- a/packages/interfold-contracts/contracts/registry/BondedVotes.sol
+++ b/packages/interfold-contracts/contracts/registry/BondedVotes.sol
@@ -7,15 +7,14 @@ pragma solidity 0.8.28;
 
 import { IVotes } from "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import { IERC5805 } from "@openzeppelin/contracts/interfaces/IERC5805.sol";
-import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {
     IERC20Metadata
 } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { IBondedCheckpoints } from "../interfaces/IBondedCheckpoints.sol";
 import { IBondingRegistry } from "../interfaces/IBondingRegistry.sol";
 // FOLD's lock schedule, the same surface the bonding registry reads. Lock-encumbered FOLD sits in
-// the holder's own wallet and cannot be moved, so it can never be deposited into the escrow —
-// which is exactly why it needs counting here rather than being left to the escrow.
+// the holder's own wallet and cannot be moved, so it can never be deposited into the escrow. The
+// adapter can count this term only for live reads because the schedule is not checkpointed.
 import {
     ILockAwareCiphernodeBondToken
 } from "../interfaces/ILockAwareCiphernodeBondToken.sol";
@@ -67,11 +66,14 @@ interface IVotingEscrow {
  * never exceed the supply they are measured against. Reading the denominator off the escrow
  * instead would omit the bonded half entirely and let participation exceed 100%.
  *
- * A THIRD SOURCE, under an escrow votes source only: FOLD still encumbered by FOLD's own vesting
- * locks. That FOLD sits in the holder's own wallet and {InterfoldToken._update} refuses to move
- * it, so it can never reach the escrow — a locked holder would be disenfranchised for the whole
- * lock schedule by a rule they cannot act on. {lockedBalanceAt} is read at the same timepoint as
- * the other two and counted for them.
+ * A THIRD SOURCE, under an escrow votes source only: current FOLD still encumbered by FOLD's own
+ * vesting locks. That FOLD sits in the holder's own wallet and {InterfoldToken._update} refuses to
+ * move it, so it can never reach the escrow. {getVotes} counts this live term so current voting
+ * power can include token-level locks.
+ *
+ * {getPastVotes} does NOT count the token lock schedule. {lockedBalanceAt} walks the account's
+ * current lock list, not a checkpointed history. A claim or link after a proposal snapshot can
+ * otherwise increase voting power at that old snapshot.
  *
  * Escrowed and bonded FOLD cannot overlap: the escrow and the registry custody the token at two
  * different addresses, so the same token can never be at both. LOCKED AND BONDED DO OVERLAP, and
@@ -118,7 +120,7 @@ contract BondedVotes is IERC5805 {
     error TokenMismatch(address ciphernodeBondToken, address votingToken);
 
     /// @notice Thrown when an escrow votes source is paired with a token that has no lock
-    /// schedule to read, which would silently disenfranchise every locked holder.
+    /// schedule to read for live voting power.
     error LockedBalancesUnsupported(address votingToken);
 
     /// @notice Thrown for the delegation entry points, which this view cannot honour.
@@ -206,10 +208,9 @@ contract BondedVotes is IERC5805 {
             revert VotesSourceMismatch(escrowToken, address(_token));
         }
 
-        // Probed once here rather than tolerated on every read. Under an escrow votes source the
-        // lock schedule is the ONLY way an encumbered holder can vote, so a token that cannot
-        // answer for it must not be deployed against silently: a `try/catch` at read time would
-        // return zero and disenfranchise exactly the holders this branch exists to enfranchise.
+        // Probed once here rather than tolerated on every live read. Under an escrow votes source
+        // the lock schedule is the only way an encumbered holder can report current voting power,
+        // so a token that cannot answer for it must not be deployed against silently.
         (bool ok, bytes memory result) = address(_token).staticcall(
             abi.encodeCall(
                 ILockAwareCiphernodeBondToken.lockedBalanceAt,
@@ -239,43 +240,38 @@ contract BondedVotes is IERC5805 {
     }
 
     /// @inheritdoc IVotes
-    /// @dev The numerator: whatever the primary source attributes to the account, plus its bonded
-    /// FOLD, plus — under an escrow votes source — the vesting-locked FOLD it cannot escrow. All
-    /// three are FOLD-denominated and read at the same timepoint.
-    ///
-    /// Cast through `SafeCast` rather than directly. `getPastBonded` already reverts on a
-    /// timepoint that has not settled, which leaves nothing wide enough to truncate — but that
-    /// makes the narrowing safe only because of the order these two lines run in, and only for
-    /// the history this contract happens to be bound to. Reverting on the narrowing itself keeps
-    /// the guarantee local to this line, where a reader can check it.
+    /// @dev The historical numerator: whatever the primary source attributes to the account, plus
+    /// its bonded FOLD. Both sources are checkpointed and read at the same timepoint. The token
+    /// lock schedule is excluded because it is present-state, not checkpointed history.
     function getPastVotes(
         address account,
         uint256 timepoint
     ) external view returns (uint256) {
         uint256 bonded = checkpoints.getPastBonded(account, timepoint);
 
-        return
-            votesSource.getPastVotes(account, timepoint) +
-            bonded +
-            _lockedVotes(account, SafeCast.toUint64(timepoint), bonded);
+        return votesSource.getPastVotes(account, timepoint) + bonded;
     }
 
-    /// @dev The vesting-locked half of the numerator, netted down by the bond.
+    /// @dev The live vesting-locked half of the numerator, netted down by the bond.
     ///
     /// Zero unless the votes source is an escrow. When the token votes for itself, locked FOLD is
     /// wallet FOLD and the token has already counted it — adding it again would simply double
     /// every locked holder's weight.
     ///
     /// Netted, because a bond satisfies a lock: FOLD that is bonded is reported by BOTH
-    /// `lockedBalanceAt` and the bonded history while existing once, and `getPastVotes` already
-    /// counts the bonded side in full. What is left is the part of the obligation the wallet must
-    /// still be holding itself.
+    /// `lockedBalanceAt` and the bonded total while existing once, and the caller already counts
+    /// the bonded side in full. What is left is the part of the obligation the wallet must still
+    /// hold.
     ///
-    /// UNLIKE the other two halves this is not a checkpointed history: `lockedBalanceAt` walks the
-    /// account's CURRENT locks and evaluates them against `timestamp`. A lock created after a
-    /// governance snapshot therefore shows up in that snapshot's answer. That is safe for the
-    /// vesting locks it exists for, which are minted or claimed rather than acquired at will, but
-    /// it is not a general-purpose past balance and must not be treated as one.
+    /// This term is read only by {getVotes}. It is deliberately absent from {getPastVotes} because
+    /// `lockedBalanceAt` walks the account's current locks, not a checkpointed history. A lock
+    /// created after a governance snapshot can appear in that snapshot's answer. That violates the
+    /// snapshot rule that past voting power must not change after the snapshot.
+    ///
+    /// Counting only PENDING would not be sufficient: a later `linkClaim` can move that PENDING
+    /// amount into a real policy, and the token still has no per-lock creation timestamp. Until a
+    /// checkpointed lock source exists, historical governance reads must use only the checkpointed
+    /// votes source and bonded history.
     /// CAPPED at the wallet balance, because netting alone stops being enough once a bond can be
     /// SLASHED. What makes `locked - bonded` a real holding is the token's own transfer rule,
     /// `balance >= locked - bonded`, enforced on every transfer. Slashing cuts the bond without
@@ -283,10 +279,8 @@ contract BondedVotes is IERC5805 {
     /// that bond is left owing more than it holds — and the uncapped term would vote with the
     /// difference, FOLD that is now in the slash recipient's hands and countable there too.
     ///
-    /// The cap reads the present balance even for a past timepoint. It is a bound, never a
-    /// source: it can only lower this term towards what the account demonstrably holds, and the
-    /// only power it can lower is the account's own. That is the right trade for a term already
-    /// evaluated from present-state locks.
+    /// The cap is a bound, never a source: the cap can only lower this term towards what the
+    /// account demonstrably holds. The only power it can lower is the account's own.
     /// @param bonded The account's bonded total at the same timepoint.
     function _lockedVotes(
         address account,

--- a/packages/interfold-contracts/test/Registry/BondedVotes.spec.ts
+++ b/packages/interfold-contracts/test/Registry/BondedVotes.spec.ts
@@ -1185,6 +1185,82 @@ describe("BondedVotes", function () {
       ).to.equal(0n);
     });
 
+    it("does not let a later CCA claim change an earlier snapshot", async function () {
+      const { veBondedVotes, ciphernodeBondToken, otherHolderAddress } =
+        await loadFixture(veSetup);
+      const [claimSource] = await ethers.getSigners();
+      const claimSourceAddress = await claimSource.getAddress();
+      const claim = ethers.parseEther("123");
+
+      expect(await ciphernodeBondToken.CLAIM_SOURCE()).to.equal(
+        claimSourceAddress,
+      );
+
+      await ciphernodeBondToken.mint(
+        claimSourceAddress,
+        claim,
+        ethers.encodeBytes32String("CCA claim"),
+      );
+
+      await time.increase(1);
+      const snapshot = (await time.latest()) - 1;
+
+      expect(
+        await veBondedVotes.getPastVotes(otherHolderAddress, snapshot),
+      ).to.equal(0n);
+
+      await ciphernodeBondToken
+        .connect(claimSource)
+        .transfer(otherHolderAddress, claim);
+
+      expect(
+        await ciphernodeBondToken.lockedBalanceOf(otherHolderAddress),
+      ).to.equal(claim);
+      expect(
+        await veBondedVotes.getPastVotes(otherHolderAddress, snapshot),
+      ).to.equal(0n);
+      expect(await veBondedVotes.getVotes(otherHolderAddress)).to.equal(claim);
+    });
+
+    it("does not let a later linked CCA claim change an earlier snapshot", async function () {
+      const { veBondedVotes, ciphernodeBondToken, otherHolderAddress } =
+        await loadFixture(veSetup);
+      const [claimSource] = await ethers.getSigners();
+      const claim = ethers.parseEther("123");
+      const policyId = ethers.encodeBytes32String("CCA_LINKED");
+
+      await ciphernodeBondToken.createLockPolicy(policyId, {
+        holdUntil: 0n,
+        unlock: {
+          anchor: 1,
+          start: 0n,
+          cliffDuration: 0n,
+          vestDuration: 2n * 365n * 24n * 60n * 60n,
+        },
+      });
+      await ciphernodeBondToken.mint(
+        await claimSource.getAddress(),
+        claim,
+        ethers.encodeBytes32String("CCA claim"),
+      );
+
+      await time.increase(1);
+      const snapshot = (await time.latest()) - 1;
+
+      await ciphernodeBondToken
+        .connect(claimSource)
+        .transfer(otherHolderAddress, claim);
+      await ciphernodeBondToken.linkClaim(otherHolderAddress, claim, policyId);
+
+      expect(
+        await ciphernodeBondToken.lockedBalanceOf(otherHolderAddress),
+      ).to.equal(claim);
+      expect(
+        await veBondedVotes.getPastVotes(otherHolderAddress, snapshot),
+      ).to.equal(0n);
+      expect(await veBondedVotes.getVotes(otherHolderAddress)).to.equal(claim);
+    });
+
     it("lets an operator vote by bonding alone, without locking", async function () {
       const { veBondedVotes, bond, bondOwnerAddress } =
         await loadFixture(veSetup);
@@ -1364,11 +1440,11 @@ describe("BondedVotes", function () {
       ).to.be.revert(ethers);
     });
 
-    /// FOLD's own vesting locks, the third source under an escrow votes source.
+    /// FOLD's own vesting locks, the current-only third source under an escrow votes source.
     ///
     /// Lock-encumbered FOLD sits in the holder's wallet and the token's transfer hook refuses to
-    /// move it, so it can never reach the escrow. Without counting it here a locked holder would
-    /// be barred from governance for the whole vesting schedule by a rule they cannot act on.
+    /// move it, so it can never reach the escrow. The historical vote path excludes this term
+    /// because the token lock schedule is not checkpointed.
     describe("vesting-locked FOLD", function () {
       const ALLOCATION = ethers.parseEther("6000");
 
@@ -1401,7 +1477,7 @@ describe("BondedVotes", function () {
         return policyId;
       }
 
-      it("counts locked FOLD for a holder who escrowed and bonded nothing", async function () {
+      it("does not count token-level locks in historical voting power", async function () {
         const { veBondedVotes, ciphernodeBondToken, otherHolderAddress } =
           await loadFixture(veSetup);
 
@@ -1415,13 +1491,13 @@ describe("BondedVotes", function () {
         ).to.equal(ALLOCATION);
         expect(
           await veBondedVotes.getPastVotes(otherHolderAddress, timepoint),
-        ).to.equal(ALLOCATION);
+        ).to.equal(0n);
         expect(await veBondedVotes.getVotes(otherHolderAddress)).to.equal(
           ALLOCATION,
         );
       });
 
-      it("adds locked FOLD to escrowed and bonded FOLD", async function () {
+      it("keeps token-level locks in current voting power", async function () {
         const {
           veBondedVotes,
           ciphernodeBondToken,
@@ -1441,7 +1517,10 @@ describe("BondedVotes", function () {
         // is FOLD the wallet is still holding and still cannot escrow.
         expect(
           await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
-        ).to.equal(LOCKED + ALLOCATION);
+        ).to.equal(LOCKED + BOND);
+        expect(await veBondedVotes.getVotes(bondOwnerAddress)).to.equal(
+          LOCKED + ALLOCATION,
+        );
       });
 
       /// The one place a naive `locked + escrowed + bonded` sum goes wrong. A bond SATISFIES a
@@ -1464,9 +1543,30 @@ describe("BondedVotes", function () {
         expect(
           await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
         ).to.equal(BOND);
+        expect(await veBondedVotes.getVotes(bondOwnerAddress)).to.equal(BOND);
       });
 
-      it("counts a bond larger than the lock exactly once", async function () {
+      it("does not count a token-level lock in historical voting power", async function () {
+        const { veBondedVotes, ciphernodeBondToken, otherHolderAddress } =
+          await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, otherHolderAddress, ALLOCATION);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await ciphernodeBondToken.balanceOf(otherHolderAddress),
+        ).to.be.greaterThan(ALLOCATION);
+        expect(
+          await veBondedVotes.getPastVotes(otherHolderAddress, timepoint),
+        ).to.equal(0n);
+        expect(await veBondedVotes.getVotes(otherHolderAddress)).to.equal(
+          ALLOCATION,
+        );
+      });
+
+      it("keeps a bond larger than the lock in historical voting power", async function () {
         const { veBondedVotes, ciphernodeBondToken, bond, bondOwnerAddress } =
           await loadFixture(veSetup);
 
@@ -1479,6 +1579,22 @@ describe("BondedVotes", function () {
         expect(
           await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
         ).to.equal(BOND);
+      });
+
+      it("counts a bond larger than the lock exactly once for current voting power", async function () {
+        const { veBondedVotes, ciphernodeBondToken, bond, bondOwnerAddress } =
+          await loadFixture(veSetup);
+
+        await allocate(ciphernodeBondToken, bondOwnerAddress, BOND / 4n);
+        await bond(BOND);
+
+        await time.increase(1);
+        const timepoint = (await time.latest()) - 1;
+
+        expect(
+          await veBondedVotes.getPastVotes(bondOwnerAddress, timepoint),
+        ).to.equal(BOND);
+        expect(await veBondedVotes.getVotes(bondOwnerAddress)).to.equal(BOND);
       });
 
       /// Soundness: what one account votes with never exceeds the supply it is measured against,
@@ -1506,10 +1622,10 @@ describe("BondedVotes", function () {
         );
       });
 
-      /// Under an escrow votes source the lock schedule is the ONLY way an encumbered holder can
-      /// vote, so a token that cannot answer for it must be rejected at construction. Tolerating
-      /// the failure at read time would return zero and disenfranchise exactly the holders the
-      /// third source exists to enfranchise — silently, and for the whole vesting schedule.
+      /// Under an escrow votes source the lock schedule is the only way an encumbered holder can
+      /// report current voting power, so a token that cannot answer for it must be rejected at
+      /// construction. Tolerating the failure at read time would silently return zero for that
+      /// current-vote path.
       it("refuses an escrow votes source over a token with no lock schedule", async function () {
         const { veBondedVotes, foldAddress } = await loadFixture(veSetup);
 
@@ -1653,7 +1769,7 @@ describe("BondedVotes", function () {
 
       /// The cap is a bound, not a source: it never lets an account vote with more than the
       /// unbonded part of its lock, and never reaches into FOLD the lock does not encumber.
-      it("caps at the lock, not at the wallet balance", async function () {
+      it("caps current voting power at the lock, not at the wallet balance", async function () {
         const { veBondedVotes, ciphernodeBondToken, otherHolderAddress } =
           await loadFixture(veSetup);
 
@@ -1668,7 +1784,10 @@ describe("BondedVotes", function () {
         ).to.be.greaterThan(ALLOCATION);
         expect(
           await veBondedVotes.getPastVotes(otherHolderAddress, timepoint),
-        ).to.equal(ALLOCATION);
+        ).to.equal(0n);
+        expect(await veBondedVotes.getVotes(otherHolderAddress)).to.equal(
+          ALLOCATION,
+        );
       });
 
       /// When the token votes for itself, locked FOLD is wallet FOLD and the token's own


### PR DESCRIPTION
## Summary

- Stop `BondedVotes.getPastVotes` from adding the token-level lock schedule because `lockedBalanceAt` is present-state, not checkpointed history.
- Keep token-level lock netting in current `getVotes` so live reads still account for encumbered FOLD under an escrow votes source.
- Add regressions for post-snapshot CCA claims, including claims later moved from `PENDING` into a real policy, and update the voting invariants/flow trace.

## Verification

- `pnpm --dir packages/interfold-contracts test test/Registry/BondedVotes.spec.ts`
- `pnpm exec prettier --check packages/interfold-contracts/contracts/registry/BondedVotes.sol packages/interfold-contracts/test/Registry/BondedVotes.spec.ts agent/INVARIANTS.md agent/flow-trace/02_TOKENS_AND_ACTIVATION.md`
- `pnpm check:docs`
- `pnpm --dir packages/interfold-contracts lint`
- pre-push hook via `git push -u origin fix/voting-issue` after `pnpm build:circuits --preset insecure-512 --committee minimum --skip-if-built`